### PR TITLE
Potential fix for code scanning alert no. 57: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -103,6 +103,8 @@ jobs:
     name: 🧽 Cleanup old Docker Hub tags
     runs-on: ubuntu-latest
     needs: build-and-push
+    permissions:
+      contents: read
     env:
       USER: thehack904
       REPO: retroiptvguide


### PR DESCRIPTION
Potential fix for [https://github.com/thehack904/RetroIPTVGuide/security/code-scanning/57](https://github.com/thehack904/RetroIPTVGuide/security/code-scanning/57)

To fix the problem, add an explicit `permissions` block to the `cleanup-dockerhub` job that grants only the minimal access required. Since this job only talks to Docker Hub using its own secrets and does not interact with the GitHub repository or packages, it can safely run with `contents: read` (or even `none`, but `contents: read` is a common minimal baseline and matches the CodeQL recommendation).

Concretely, in `.github/workflows/docker-publish.yml`, within the `cleanup-dockerhub` job definition (lines 101–111), insert a `permissions:` section at the same indentation level as `runs-on`, `needs`, and `env`. Set it to:

```yaml
permissions:
  contents: read
```

This mirrors the minimal pattern suggested by CodeQL, keeps the job functional (it doesn’t rely on elevated `GITHUB_TOKEN` rights), and documents that the job does not need write permissions.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
