### PR TITLE
v4.9.5 Release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ This project follows [Semantic Versioning](https://semver.org/).
 
 ---
 
-## v4.9.5 - 2026-04-29
+## v4.9.5 - 2026-05-25
 
 ### Added
 - Added channel logo to be displayed in "Current Program" information area.

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 <p align="center">
   <a href="https://github.com/thehack904/RetroIPTVGuide">
-    <img src="https://img.shields.io/badge/version-v4.9.4-blue?style=for-the-badge" alt="Version">
+    <img src="https://img.shields.io/badge/version-v4.9.5-blue?style=for-the-badge" alt="Version">
   </a>
   <a href="https://github.com/thehack904/RetroIPTVGuide/pkgs/container/retroiptvguide">
     <img src="https://img.shields.io/badge/GHCR-ghcr.io/thehack904/retroiptvguide-green?style=for-the-badge&logo=docker" alt="GHCR">

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -4,7 +4,7 @@ This document tracks **planned upgrades** and ideas for improving the IPTV Flask
 These are **not yet implemented**, partially implemented, or completed in previous releases.
 
 ---
-# Current Version: **v4.9.4 (2026-04-25)**
+# Current Version: **v4.9.5 (2026-05-25)**
 
 ---
 

--- a/app.py
+++ b/app.py
@@ -1,6 +1,6 @@
 # app.py — merged version (features from both sources)
-APP_VERSION = "v4.9.5-beta"
-APP_RELEASE_DATE = "2026-05-07"
+APP_VERSION = "v4.9.5"
+APP_RELEASE_DATE = "2026-05-25"
 
 from flask import Flask, render_template, request, redirect, url_for, flash, session, jsonify, abort, make_response
 from flask_login import LoginManager, UserMixin, login_user, login_required, logout_user, current_user

--- a/retroiptv_linux.sh
+++ b/retroiptv_linux.sh
@@ -3,7 +3,7 @@
 # License: Creative Commons Attribution-NonCommercial-ShareAlike 4.0 International (CC BY-NC-SA 4.0)
 
 set -euo pipefail
-VERSION="4.9.4"
+VERSION="4.9.5"
 TIMESTAMP=$(date +"%Y-%m-%d_%H-%M-%S")
 LOGFILE="retroiptv_${TIMESTAMP}.log"
 exec > >(tee -a "$LOGFILE") 2>&1

--- a/retroiptv_rpi.sh
+++ b/retroiptv_rpi.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-VERSION="4.9.4"
+VERSION="4.9.5"
 # RetroIPTVGuide Raspberry Pi Installer (Headless, Pi3/4/5)
 # Installs to /home/iptv/iptv-server for consistency with Debian/Windows
 # Logs to /var/log/retroiptvguide/install-YYYYMMDD-HHMMSS.log

--- a/retroiptv_windows.bat
+++ b/retroiptv_windows.bat
@@ -3,7 +3,7 @@ mode con: cols=160 lines=50
 
 REM ============================================================
 REM RetroIPTVGuide Windows Unified Installer / Uninstaller
-REM Version: v4.9.4
+REM Version: v4.9.5
 REM License: Creative Commons BY-NC-SA 4.0
 REM ============================================================
 
@@ -31,7 +31,7 @@ if /i "%choice%"=="Y" (
 
 :continue
 setlocal
-set "VERSION=4.9.4"
+set "VERSION=4.9.5"
 set "REPO_URL=https://github.com/thehack904/RetroIPTVGuide.git"
 set "ZIP_URL=https://github.com/thehack904/RetroIPTVGuide/archive/refs/heads/main.zip"
 set "INSTALL_DIR=%~dp0RetroIPTVGuide"

--- a/retroiptv_windows.ps1
+++ b/retroiptv_windows.ps1
@@ -1,7 +1,7 @@
 <# 
 RetroIPTVGuide Windows Installer/Uninstaller
 Filename: retroiptv_windows.ps1
-Version: 4.9.4
+Version: 4.9.5
 
 License: Creative Commons Attribution-NonCommercial-ShareAlike 4.0 International
 https://creativecommons.org/licenses/by-nc-sa/4.0/
@@ -55,7 +55,7 @@ if (-not ([Security.Principal.WindowsPrincipal] [Security.Principal.WindowsIdent
 $ErrorActionPreference = 'Stop'
 $PSDefaultParameterValues['Out-File:Encoding'] = 'utf8'
 
-$VERSION = "4.9.4"
+$VERSION = "4.9.5"
 $ScriptDir = Split-Path -Parent -Path $MyInvocation.MyCommand.Path
 Set-Location $ScriptDir
 


### PR DESCRIPTION
## v4.9.5 - 2026-05-25

### Added
- Added channel logo to be displayed in "Current Program" information area.
- Added channel logo support to the `/api/current_program` response.
  - The endpoint now returns a top-level `logo` field for the requested channel.
  - If a channel has no logo, the endpoint returns an empty string instead of omitting the field.
  - Added regression coverage in `tests/test_current_program_logo.py` to ensure the logo field is present without breaking existing program metadata.
- Added ability to hide channels per user.
  - Users can right-click any channel name in the guide grid to access a context menu with **Hide Channel** / **Unhide Channel** options; hidden channels are persisted server-side per user account.
  - Added **Show/Hide Hidden Channels** toggle to the **Guide Preferences** submenu in the Settings menu (desktop and mobile) so users can reveal or re-hide all their hidden channels with one click.
  - Admins can now view a summary of hidden channels per user and **set hidden channels directly** from the **Manage Users** preferences panel using a multi-select channel picker — selecting channels marks them as hidden, deselecting all clears the list.
- Added **IPTV Backends** wiki page (`docs/wiki/IPTV-Backends.md`) listing compatible IPTV server software that provides HLS segmenter streams (#189).
  - Documents Tunarr, dizqueTV, Channels DVR, TVHeadend, Jellyfin, Plex, and Emby as ErsatzTV alternatives.
  - Includes an FFmpeg direct-segmenter example for advanced users.
  - Includes guidance on using the built-in stream detector to verify backend compatibility.
  - Updated `README.md` and `docs/wiki/FAQ.md` to reference the new page and broaden ErsatzTV-specific language.

### Removed
- Removed **Sizzle Reels** feature (hover-to-preview channel stream). The `sizzle_reels_enabled` preference key has been retired; any stored values are silently ignored going forward.

### Fixed
- Fixed virtual channel standalone pages not fitting the viewport on mobile devices.
  - Updated `weather.html`, `news.html`, `status.html`, `traffic.html`, `nasa.html`, and `on_this_day.html` to use `height: 100vh` (instead of `min-height: 100vh`) so the page fills the screen without overflow.
  - Added `calc(100vh * 16 / 9)` as an additional constraint to each channel frame's `width: min(...)` so the 16:9 frame stays fully visible and correctly proportioned on landscape mobile screens. This brings these pages in line with `sports.html` and `updates.html`.
- Improved mobile layout of the Virtual Channels admin page (`/virtual_channels`):
  - Channel list items now wrap gracefully on narrow screens instead of overflowing.
  - Channel names allow wrapping on very small viewports.
  - Per-channel preferences fields stack vertically at ≤ 700 px.
  - Traffic demo city table gains horizontal scrolling so all columns remain accessible on narrow screens.
  - Audio file list items stack vertically on mobile so filenames and audio controls are readable.
  - Drag handles in the Channel Order list are larger for easier touch interaction.
  - Page title font size is reduced slightly on narrow screens to prevent overflow.