### PR TITLE
v4.9.6

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -39,7 +39,7 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
 
     - name: Initialize CodeQL
       uses: github/codeql-action/init@v4

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -25,7 +25,7 @@ jobs:
 
     steps:
       - name: 🧾 Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: 🔡 Normalize image name to lowercase
         id: prep

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -21,7 +21,7 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
@@ -38,7 +38,7 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Set up Python
         uses: actions/setup-python@v5
         with:

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -20,7 +20,7 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
 
     - name: Set up Python
       uses: actions/setup-python@v5

--- a/.github/workflows/sync-wiki.yml
+++ b/.github/workflows/sync-wiki.yml
@@ -21,7 +21,7 @@ jobs:
 
     steps:
       - name: 🧾 Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           persist-credentials: false
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,121 @@ This project follows [Semantic Versioning](https://semver.org/).
 
 ---
 
+## v4.9.6 - 2026-06-11
+
+### Added
+
+* Added **Favorites (lightweight)** feature.
+
+  * Users can right-click any channel name in the guide grid to **Add to Favorites** or **Remove from Favorites**.
+  * Favorite channels are persisted server-side per user account through the existing user preferences system.
+  * Favorited channels are marked with a star badge in the guide.
+  * Added **Show Favorites Only** toggle to the **Guide Preferences** submenu on desktop and mobile.
+  * Toggle label updates to **Show All Channels** when the favorites-only filter is active.
+
+* Added **Channel Info Banner** to the guide player.
+
+  * Banner appears when tuning a channel and displays channel logo, channel number, channel name, current program title, program time range, progress bar, remaining time, and description.
+  * Added an info button to manually toggle the banner.
+  * Added keyboard shortcut support using the `i` key when focus is not inside an input field.
+  * Added Channel Info Banner support inside virtual-channel fullscreen overlay mode.
+
+* Added **Guide Search / Filter** panel.
+
+  * Added SEARCH link to the guide header on desktop and mobile.
+  * Users can search by channel name, program title, program description, group/type, category, and color metadata.
+  * Added type filter dropdown populated from channel groups, virtual-channel markers, and XMLTV program categories.
+  * Search/filter behavior updates visible guide rows and recomputes auto-scroll loops.
+
+* Added **Channel Number Entry**.
+
+  * Added `static/js/channel-number-entry.js`.
+  * Users can type numeric channel numbers to jump directly to a channel.
+  * Supports delayed auto-navigation after number entry.
+  * Supports immediate confirmation with Enter.
+  * Supports canceling entry with Escape or GoBack.
+  * Supports decimal/sub-channel numbers such as `2.1`, `16.5`, and `31.2`.
+  * Displays a retro-style channel-number HUD while typing.
+  * Uses `tvg-chno` from M3U playlists when available, with row-index fallback when missing.
+
+* Added **Last Channel Return**.
+
+  * Stores the previously watched channel before switching to a new channel.
+  * Added `window.returnToLastChannel()` helper.
+  * Added `L` key shortcut support through channel-number entry handling.
+
+* Added support for parsing `tvg-chno` values from M3U playlists.
+
+  * Parsed channel numbers are stored on channel metadata as `tvg_chno`.
+  * Guide rows now expose channel numbers through `data-chan-num`.
+  * `/api/channels` now returns parsed `tvg-chno` values as the channel number when available.
+
+* Added optional user-controlled channel-number display.
+
+  * Added `channel_numbers_enabled` to default user preferences.
+  * Added **Show Channel Numbers / Hide Channel Numbers** toggle to Guide Preferences on desktop and mobile.
+  * User-injected channel numbers are hidden automatically for themes that already include built-in channel numbers, including `tvguide1990` and `classic-cable`.
+
+* Added XMLTV metadata parsing for guide filtering.
+
+  * Program categories are now parsed from XMLTV `<category>` entries.
+  * Program color metadata is now parsed from XMLTV `<colour>` and `<color>` entries.
+  * Guide program blocks now expose category and color metadata through `data-categories` and `data-colors`.
+
+### Changed
+
+* Improved guide player fullscreen behavior.
+
+  * Native video fullscreen now uses `object-fit: contain` so video letterboxes instead of cropping.
+  * Fullscreen control labeling was generalized from virtual-channel-only wording to broader fullscreen wording.
+
+* Improved guide preference handling.
+
+  * User preferences now include `favorite_channels` and `channel_numbers_enabled`.
+  * API preference updates sanitize `favorite_channels` as a list of non-empty strings.
+  * API preference updates coerce invalid `channel_numbers_enabled` values to `false`.
+
+* Expanded the right-click channel context menu.
+
+  * Added favorite and unfavorite actions.
+  * Preserved existing play, auto-load, hide, and unhide actions.
+
+### Fixed
+
+* Fixed channel info display behavior for virtual channel fullscreen overlays.
+
+  * Info banner and info button now appear correctly in fullscreen overlay mode.
+  * Info banner controls fade consistently with fullscreen overlay controls.
+
+* Fixed native video fullscreen cropping.
+
+  * Browser fullscreen entered from the video control bar now preserves full video framing instead of cropping to fill.
+
+* Fixed guide search/filter layout integration.
+
+  * Opening or closing the search panel now refreshes the fixed time bar and now-line positioning.
+
+### Tests
+
+* Added `tests/test_channel_info_banner.py`.
+* Added `tests/test_channel_number_entry.py`.
+* Added `tests/test_guide_search_filter.py`.
+* Added `tests/test_last_channel_return.py`.
+* Added `tests/test_user_prefs_channel_numbers.py`.
+* Expanded `tests/test_user_prefs.py` coverage for:
+
+  * favorite channel defaults
+  * saving and retrieving favorites
+  * API favorite-channel updates
+  * invalid favorite-channel sanitization
+  * preserving favorites during partial preference updates
+  * channel-number preference toggling
+  * invalid channel-number preference sanitization
+  * guide preference controls for channel-number display
+
+
+---
+
 ## v4.9.5 - 2026-05-25
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 <p align="center">
   <a href="https://github.com/thehack904/RetroIPTVGuide">
-    <img src="https://img.shields.io/badge/version-v4.9.5-blue?style=for-the-badge" alt="Version">
+    <img src="https://img.shields.io/badge/version-v4.9.6-blue?style=for-the-badge" alt="Version">
   </a>
   <a href="https://github.com/thehack904/RetroIPTVGuide/pkgs/container/retroiptvguide">
     <img src="https://img.shields.io/badge/GHCR-ghcr.io/thehack904/retroiptvguide-green?style=for-the-badge&logo=docker" alt="GHCR">

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -4,7 +4,7 @@ This document tracks **planned upgrades** and ideas for improving the IPTV Flask
 These are **not yet implemented**, partially implemented, or completed in previous releases.
 
 ---
-# Current Version: **v4.9.5 (2026-05-25)**
+# Current Version: **v4.9.6 (2026-06-11)**
 
 ---
 
@@ -41,10 +41,10 @@ These are **not yet implemented**, partially implemented, or completed in previo
 - [x] Fullscreen improvements for virtual channels *(v4.9.3)*  
 - [x] Channel Mix dynamic fullscreen switching *(v4.9.3)*  
 - [ ] Search/filter box  
-- [ ] Favorites (lightweight)  
-- [ ] Channel Info Banner  
-- [ ] Channel number entry  
-- [ ] Last channel return  
+- [x] Favorites (lightweight) *(v4.9.6)*  
+- [x] Channel Info Banner *(v4.9.6)*  
+- [x] Channel number entry *(v4.9.6)*  
+- [x] Last channel return *(v4.9.6)*  
 - [ ] Browse mode  
 - [ ] "What's On Now" view  
 - [ ] Channel health indicators (lightweight only)  
@@ -86,7 +86,7 @@ These are **not yet implemented**, partially implemented, or completed in previo
 ---
 
 ### 7. New Features
-- [ ] Favorites system (lightweight)  
+- [x] Favorites system (lightweight) *(v4.9.6)*  
 - [ ] Smart filtering (simple implementation only)  
 
 ---

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -40,7 +40,7 @@ These are **not yet implemented**, partially implemented, or completed in previo
 - [x] Responsive layout *(v4.2.0)*  
 - [x] Fullscreen improvements for virtual channels *(v4.9.3)*  
 - [x] Channel Mix dynamic fullscreen switching *(v4.9.3)*  
-- [ ] Search/filter box  
+- [x] Search/filter box *(v4.9.6)* 
 - [x] Favorites (lightweight) *(v4.9.6)*  
 - [x] Channel Info Banner *(v4.9.6)*  
 - [x] Channel number entry *(v4.9.6)*  
@@ -57,11 +57,11 @@ These are **not yet implemented**, partially implemented, or completed in previo
 
 ### 4. User Management
 - [x] User management UI *(v4.0.0)*  
-- [-] Basic admin-only access model  
+- [x] Basic admin-only access model *(initial v1.x; expanded through v2.0.0, v4.0.0, v4.9.2, and v4.9.3)* 
 - [x] Last login tracking *(v4.5.0)*  
 - [x] Auto-Load Channel *(v4.7.0)*  
 - [x] Assigned Tuner per User *(v4.7.0)*  
-- [ ] User role/channel restrictions  
+- [x] User role/channel restrictions *(v4.7.0 / v4.9.5)*
 
 ---
 
@@ -87,7 +87,7 @@ These are **not yet implemented**, partially implemented, or completed in previo
 
 ### 7. New Features
 - [x] Favorites system (lightweight) *(v4.9.6)*  
-- [ ] Smart filtering (simple implementation only)  
+- [x] Smart filtering (simple implementation only) *(v4.9.6)* 
 
 ---
 
@@ -128,6 +128,6 @@ These are **not yet implemented**, partially implemented, or completed in previo
 ## User Submitted Enhancements
 - [x] Resize Pop Out Video *(v4.6.0)*
 - [x] Resize video *(v4.6.0)*
-- [ ] Auto load Channel from Guide  
+- [x] Auto load Channel from Guide  *(v4.8.0)*
 - [x] Adjustable scrolling speed *(v4.6.0)*
 - [x] Unraid Template

--- a/app.py
+++ b/app.py
@@ -1,6 +1,6 @@
 # app.py — merged version (features from both sources)
-APP_VERSION = "v4.9.5"
-APP_RELEASE_DATE = "2026-05-25"
+APP_VERSION = "v4.9.6"
+APP_RELEASE_DATE = "2026-06-11"
 
 from flask import Flask, render_template, request, redirect, url_for, flash, session, jsonify, abort, make_response
 from flask_login import LoginManager, UserMixin, login_user, login_required, logout_user, current_user
@@ -633,6 +633,8 @@ def inject_tuner_context():
 _DEFAULT_PREFS = {
     "auto_load_channel": None,
     "hidden_channels": [],
+    "favorite_channels": [],
+    "channel_numbers_enabled": False,
     "default_theme": None,
 }
 
@@ -737,12 +739,14 @@ def parse_m3u(m3u_url):
             tvg_id = tvg_id_match.group(1) if tvg_id_match else name
             group_match = re.search(r'group-title="([^"]*)"', info, re.IGNORECASE)
             group = group_match.group(1).strip() if group_match else ''
+            tvg_chno_match = re.search(r'tvg-chno="([^"]*)"', info)
+            tvg_chno = tvg_chno_match.group(1).strip() if tvg_chno_match else ''
             url = lines[i+1].strip() if i+1 < len(lines) else ''
 
             if url.endswith('.ts'):
                 url = url.replace('.ts', '.m3u8')
 
-            channels.append({'name': name, 'logo': logo, 'url': url, 'tvg_id': tvg_id, 'group': group})
+            channels.append({'name': name, 'logo': logo, 'url': url, 'tvg_id': tvg_id, 'group': group, 'tvg_chno': tvg_chno})
     return channels
 
 # ------------------- XMLTV EPG Parsing -------------------
@@ -785,10 +789,28 @@ def parse_epg(xml_url):
         desc = prog.find('desc').text if prog.find('desc') is not None else ''
         icon_el = prog.find('icon')
         icon = icon_el.attrib.get('src', '') if icon_el is not None else ''
+        categories = [
+            (cat.text or '').strip()
+            for cat in prog.findall('category')
+            if (cat.text or '').strip()
+        ]
+        colors = [
+            (el.text or '').strip()
+            for el in (prog.findall('colour') + prog.findall('color'))
+            if (el.text or '').strip()
+        ]
 
         if cid not in programs:
             programs[cid] = []
-        programs[cid].append({'title': title, 'desc': desc, 'start': start, 'stop': stop, 'icon': icon})
+        programs[cid].append({
+            'title': title,
+            'desc': desc,
+            'start': start,
+            'stop': stop,
+            'icon': icon,
+            'categories': categories,
+            'colors': colors,
+        })
     return programs
 
 # ------------------- EPG Fallback Helper -------------------
@@ -4663,6 +4685,22 @@ def api_user_prefs_post():
         alc = data["auto_load_channel"]
         if not (isinstance(alc, dict) and alc.get("id")):
             data["auto_load_channel"] = None
+
+    # Sanitise favorite_channels: must be a list of non-empty strings
+    if "favorite_channels" in data:
+        fc = data["favorite_channels"]
+        if isinstance(fc, list):
+            data["favorite_channels"] = [str(c) for c in fc if c]
+        else:
+            data["favorite_channels"] = []
+
+    # Sanitise channel_numbers_enabled: must be a boolean
+    if "channel_numbers_enabled" in data:
+        data["channel_numbers_enabled"] = (
+            data["channel_numbers_enabled"]
+            if isinstance(data["channel_numbers_enabled"], bool)
+            else False
+        )
 
     save_user_prefs(current_user.username, data)
     return jsonify({"status": "ok", "prefs": get_user_prefs(current_user.username)})

--- a/retroiptv_linux.sh
+++ b/retroiptv_linux.sh
@@ -3,7 +3,7 @@
 # License: Creative Commons Attribution-NonCommercial-ShareAlike 4.0 International (CC BY-NC-SA 4.0)
 
 set -euo pipefail
-VERSION="4.9.5"
+VERSION="4.9.6"
 TIMESTAMP=$(date +"%Y-%m-%d_%H-%M-%S")
 LOGFILE="retroiptv_${TIMESTAMP}.log"
 exec > >(tee -a "$LOGFILE") 2>&1

--- a/retroiptv_rpi.sh
+++ b/retroiptv_rpi.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-VERSION="4.9.5"
+VERSION="4.9.6"
 # RetroIPTVGuide Raspberry Pi Installer (Headless, Pi3/4/5)
 # Installs to /home/iptv/iptv-server for consistency with Debian/Windows
 # Logs to /var/log/retroiptvguide/install-YYYYMMDD-HHMMSS.log

--- a/retroiptv_windows.bat
+++ b/retroiptv_windows.bat
@@ -3,7 +3,7 @@ mode con: cols=160 lines=50
 
 REM ============================================================
 REM RetroIPTVGuide Windows Unified Installer / Uninstaller
-REM Version: v4.9.5
+REM Version: v4.9.6
 REM License: Creative Commons BY-NC-SA 4.0
 REM ============================================================
 
@@ -31,7 +31,7 @@ if /i "%choice%"=="Y" (
 
 :continue
 setlocal
-set "VERSION=4.9.5"
+set "VERSION=4.9.6"
 set "REPO_URL=https://github.com/thehack904/RetroIPTVGuide.git"
 set "ZIP_URL=https://github.com/thehack904/RetroIPTVGuide/archive/refs/heads/main.zip"
 set "INSTALL_DIR=%~dp0RetroIPTVGuide"

--- a/retroiptv_windows.ps1
+++ b/retroiptv_windows.ps1
@@ -1,7 +1,7 @@
 <# 
 RetroIPTVGuide Windows Installer/Uninstaller
 Filename: retroiptv_windows.ps1
-Version: 4.9.5
+Version: 4.9.6
 
 License: Creative Commons Attribution-NonCommercial-ShareAlike 4.0 International
 https://creativecommons.org/licenses/by-nc-sa/4.0/
@@ -55,7 +55,7 @@ if (-not ([Security.Principal.WindowsPrincipal] [Security.Principal.WindowsIdent
 $ErrorActionPreference = 'Stop'
 $PSDefaultParameterValues['Out-File:Encoding'] = 'utf8'
 
-$VERSION = "4.9.5"
+$VERSION = "4.9.6"
 $ScriptDir = Split-Path -Parent -Path $MyInvocation.MyCommand.Path
 Set-Location $ScriptDir
 

--- a/static/css/base.css
+++ b/static/css/base.css
@@ -290,6 +290,12 @@ body { font-family: Arial, sans-serif; margin:0; }
 }
 .chan-name img { width:28px; height:28px; object-fit:contain; margin-bottom: 2px; }
 .chan-name span { white-space:nowrap; overflow:hidden; text-overflow:ellipsis; max-width:100%; }
+.chan-name .user-channel-number {
+  font-size: 0.78em;
+  font-weight: 700;
+  opacity: 0.9;
+  letter-spacing: 0.02em;
+}
 .grid-row  { position:relative; height:52px; border-bottom:1px solid; }
 .grid-content { position:relative; width: var(--total-width); min-height:100%; }
 .program {
@@ -778,3 +784,15 @@ body.ersatztv{--arrow-collapsed:"▶";--arrow-expanded:"▼";}
   font-size: 0.75em;
   opacity: 0.8;
 }
+
+/* Favorite channels: star badge on the channel name cell */
+.guide-row.chan-favorite > .chan-col .chan-name::before {
+  content: '⭐ ';
+  font-size: 0.75em;
+  opacity: 0.9;
+}
+
+/* Favorites-only filter: hide non-favourite rows when the toggle is active */
+body.favorites-only .guide-row:not(.chan-favorite) { display: none; }
+/* Always keep the time-header row visible */
+body.favorites-only .guide-row.hide-in-grid { display: flex !important; }

--- a/static/js/channel-number-entry.js
+++ b/static/js/channel-number-entry.js
@@ -1,0 +1,264 @@
+/**
+ * channel-number-entry.js — Classic TV-style channel number entry
+ *
+ * When the user presses digit keys (0–9) anywhere in the guide, a retro HUD
+ * overlay appears showing the accumulated characters.  After a short idle
+ * timeout (1.5 s) the guide scrolls to the matching channel and starts
+ * playback.  Pressing Enter/OK confirms immediately; Escape cancels.
+ *
+ * Sub-channel numbers (e.g. 2.1, 16.5, 31.2) are supported: pressing the
+ * period key appends a "." to the buffer so the user can type the full
+ * sub-channel designator.
+ *
+ * Channel numbers are read from the data-chan-num attribute on each
+ * .chan-name element (set by guide.html using tvg_chno or a sequential
+ * fallback index that matches the tvguide1990 / classic-cable capsule numbers).
+ */
+(function () {
+  'use strict';
+
+  /* ── Configuration ──────────────────────────────────────────────────────── */
+  var ENTRY_TIMEOUT_MS = 1500;  // ms after last keypress before auto-navigate
+  var MAX_CHARS        = 5;     // longest channel id accepted (e.g. "123.4")
+
+  /* ── State ──────────────────────────────────────────────────────────────── */
+  var buffer = '';   // accumulated digit string
+  var timer  = null; // auto-navigate timeout handle
+  var hudEl  = null; // HUD DOM node (created lazily)
+
+  /* ── Inject HUD styles ──────────────────────────────────────────────────── */
+  var style = document.createElement('style');
+  style.textContent = [
+    '#chan-num-hud {',
+    '  position: fixed;',
+    '  top: 50%;',
+    '  left: 50%;',
+    '  transform: translate(-50%, -50%);',
+    '  background: rgba(0, 0, 0, 0.88);',
+    '  color: #f90;',
+    '  font-family: "Courier New", Courier, monospace;',
+    '  font-size: clamp(3rem, 8vw, 6rem);',
+    '  font-weight: 700;',
+    '  letter-spacing: 0.12em;',
+    '  padding: 0.25em 0.6em;',
+    '  border: 3px solid #f90;',
+    '  border-radius: 8px;',
+    '  box-shadow: 0 0 28px rgba(255,153,0,0.55), inset 0 0 14px rgba(255,153,0,0.1);',
+    '  text-shadow: 0 0 14px #f90;',
+    '  z-index: 9998;',
+    '  pointer-events: none;',
+    '  user-select: none;',
+    '  min-width: 2.5em;',
+    '  text-align: center;',
+    '  display: none;',
+    '  opacity: 1;',
+    '  transition: opacity 0.3s ease;',
+    '}',
+    '#chan-num-hud.visible { display: block; }',
+    '#chan-num-hud.fading { opacity: 0; }',
+    /* label beneath the number */
+    '#chan-num-hud .hud-label {',
+    '  display: block;',
+    '  font-size: 0.3em;',
+    '  letter-spacing: 0.2em;',
+    '  color: rgba(255,153,0,0.7);',
+    '  text-transform: uppercase;',
+    '  margin-top: 0.1em;',
+    '  text-shadow: none;',
+    '}'
+  ].join('\n');
+  document.head.appendChild(style);
+
+  /* ── HUD helpers ────────────────────────────────────────────────────────── */
+  function ensureHud() {
+    if (hudEl) return hudEl;
+    hudEl = document.createElement('div');
+    hudEl.id = 'chan-num-hud';
+    hudEl.setAttribute('aria-live', 'assertive');
+    hudEl.setAttribute('aria-atomic', 'true');
+    hudEl.setAttribute('role', 'status');
+    document.body.appendChild(hudEl);
+    return hudEl;
+  }
+
+  function showHud(digits, label) {
+    var el = ensureHud();
+    el.textContent = '';
+
+    var numSpan = document.createElement('span');
+    numSpan.textContent = digits;
+    el.appendChild(numSpan);
+
+    if (label) {
+      var lblSpan = document.createElement('span');
+      lblSpan.className = 'hud-label';
+      lblSpan.textContent = label;
+      el.appendChild(lblSpan);
+    }
+
+    el.classList.remove('fading');
+    el.classList.add('visible');
+  }
+
+  function hideHud() {
+    if (!hudEl) return;
+    hudEl.classList.add('fading');
+    setTimeout(function () {
+      if (hudEl) hudEl.classList.remove('visible', 'fading');
+    }, 300);
+  }
+
+  /* ── Channel index ──────────────────────────────────────────────────────── */
+  /**
+   * Build a map of channel-number → .chan-name element.
+   * Primary keys come from data-chan-num (set by the template); secondary keys
+   * include the visible row index (1-based), so users can also jump by the
+   * displayed sequence when virtual channels shift row positions.
+   * Excludes elements inside auto-scroll clones so duplicate DOM nodes don't
+   * shadow the originals.
+   */
+  function buildIndex() {
+    var index = {};
+    var els = Array.from(document.querySelectorAll('.chan-name')).filter(function (el) {
+      // Skip cloned rows used by the auto-scroll module
+      return !el.closest('.__auto_scroll_clone');
+    });
+
+    function setPrimary(num, el) {
+      if (!num) return;
+      if (!index[num]) {
+        index[num] = el;
+        return;
+      }
+      var existing = index[num];
+      var existingIsVirtual = existing.dataset.isVirtual === 'true';
+      var candidateIsVirtual = el.dataset.isVirtual === 'true';
+      if (candidateIsVirtual && !existingIsVirtual) index[num] = el;
+    }
+
+    // Pass 1: explicit channel numbers (including decimals like 2.1)
+    els.forEach(function (el) {
+      var num = (el.dataset.chanNum || '').trim();
+      setPrimary(num, el);
+    });
+
+    // Pass 2: sequential row numbers, used as fallback aliases
+    els.forEach(function (el, i) {
+      var seqNum = String(i + 1);
+      if (!index[seqNum]) index[seqNum] = el;
+    });
+
+    return index;
+  }
+
+  /* ── Navigation ─────────────────────────────────────────────────────────── */
+  function navigate() {
+    var digits = buffer;
+    reset(/* keepHud= */ true);
+
+    var index = buildIndex();
+    var target = index[digits];
+
+    if (!target) {
+      // Channel not found — flash an error label then dismiss
+      showHud(digits, 'not found');
+      setTimeout(hideHud, 900);
+      return;
+    }
+
+    hideHud();
+
+    // Scroll the channel row into view
+    target.scrollIntoView({ block: 'center', behavior: 'smooth' });
+
+    // Give the browser a moment to finish scrolling before triggering playback.
+    // Move focus to the target first so screen readers announce the selection.
+    setTimeout(function () {
+      target.focus();
+      target.click();
+    }, 180);
+  }
+
+  function reset(keepHud) {
+    if (timer) { clearTimeout(timer); timer = null; }
+    buffer = '';
+    if (!keepHud) hideHud();
+  }
+
+  /* ── Keyboard handler ───────────────────────────────────────────────────── */
+  function onKeyDown(e) {
+    // Ignore keypresses directed at text inputs
+    var tag = (e.target && e.target.tagName) ? e.target.tagName.toLowerCase() : '';
+    if (tag === 'input' || tag === 'textarea' || tag === 'select') return;
+
+    var key = e.key;
+
+    /* ── Digit keys (0–9) ─────────────────────────────────────────────────── */
+    if (/^[0-9]$/.test(key)) {
+      e.preventDefault();
+      if (buffer.length >= MAX_CHARS) {
+        // If a decimal point is already in the buffer the sub-channel is fully
+        // specified — ignore further digits rather than corrupting the number.
+        if (buffer.indexOf('.') !== -1) return;
+        // Pure-digit entry: slide the window (drop oldest digit, append new).
+        buffer = buffer.slice(1) + key;
+      } else {
+        buffer += key;
+      }
+      showHud(buffer, 'ch');
+      if (timer) clearTimeout(timer);
+      timer = setTimeout(navigate, ENTRY_TIMEOUT_MS);
+      return;
+    }
+
+    /* ── Period — sub-channel separator (e.g. 2.1, 16.5) ────────────────── */
+    if (key === '.' && buffer.length > 0 && buffer.indexOf('.') === -1) {
+      e.preventDefault();
+      buffer += '.';
+      showHud(buffer, 'ch');
+      if (timer) clearTimeout(timer);
+      timer = setTimeout(navigate, ENTRY_TIMEOUT_MS);
+      return;
+    }
+
+    /* ── Enter / OK — confirm immediately ────────────────────────────────── */
+    if (key === 'Enter' && buffer) {
+      // Consume the event so TV remote nav (if active) doesn't also fire
+      e.preventDefault();
+      e.stopImmediatePropagation();
+      if (timer) clearTimeout(timer);
+      navigate();
+      return;
+    }
+
+    /* ── Escape / Back — cancel ──────────────────────────────────────────── */
+    if ((key === 'Escape' || key === 'GoBack') && buffer) {
+      e.preventDefault();
+      reset();
+      return;
+    }
+
+    /* ── L key — return to last channel (only when no digit entry is active) */
+    if ((key === 'l' || key === 'L') && !buffer) {
+      if (typeof window.returnToLastChannel === 'function' && window.lastChannelMeta) {
+        e.preventDefault();
+        window.returnToLastChannel();
+      }
+      return;
+    }
+  }
+
+  /* ── Init ───────────────────────────────────────────────────────────────── */
+  // Bubble phase (capture=false) so this runs alongside tv-remote-nav handlers.
+  // stopImmediatePropagation on Enter prevents other bubble-phase handlers from
+  // also acting when the user is mid-entry.
+  document.addEventListener('keydown', onKeyDown, false);
+
+  // Expose a minimal public API so other modules can query / reset state
+  window.__chanNumEntry = {
+    /** True while the user is mid-entry (buffer non-empty). */
+    isActive: function () { return buffer.length > 0; },
+    /** Programmatically cancel any pending entry. */
+    cancel:   function () { reset(); }
+  };
+})();

--- a/static/js/user-prefs.js
+++ b/static/js/user-prefs.js
@@ -2,6 +2,7 @@
 // Features:
 //   • Auto-load channel: automatically plays a saved channel when the guide opens
 //   • Hidden channels:   hides selected channels from the guide grid (right-click to hide)
+//   • Favorite channels: marks favorite channels with a star; optional filter to show only favorites
 //
 // Prefs are loaded from window.__initialUserPrefs (injected by guide.html) and
 // saved back to the server via POST /api/user_prefs.
@@ -14,16 +15,23 @@
 //   .toggleShowHidden()       — toggle visibility of hidden rows in the guide
 //   .hideChannel(id)          — add channel to hidden list
 //   .unhideChannel(id)        — remove channel from hidden list
+//   .addFavorite(id)          — add channel to favorites list
+//   .removeFavorite(id)       — remove channel from favorites list
+//   .toggleShowFavoritesOnly() — toggle guide filter to show only favorite channels
 
 (function () {
   'use strict';
 
   // ─── State ────────────────────────────────────────────────────────────────
   let prefs = Object.assign(
-    { auto_load_channel: null, hidden_channels: [] },
+    { auto_load_channel: null, hidden_channels: [], favorite_channels: [], channel_numbers_enabled: false },
     (typeof window.__initialUserPrefs === 'object' && window.__initialUserPrefs) || {}
   );
   let showingHidden = false;   // current toggle state for "show hidden channels"
+  let showingFavoritesOnly = false; // current toggle state for "show favorites only"
+  let channelNumberReapplyQueued = false;
+  const CHANNEL_NUMBER_PREFIX = 'CH ';
+  const THEMES_WITH_BUILT_IN_CHANNEL_NUMBERS = ['tvguide1990', 'classic-cable'];
 
   // ─── Helpers ──────────────────────────────────────────────────────────────
   function log() {
@@ -97,6 +105,123 @@
     await savePatch({ hidden_channels: next });
     applyHiddenChannels();
     log('unhidden channel', cid);
+  }
+
+  // ─── Favorite channels ────────────────────────────────────────────────────
+  function applyFavoriteChannels() {
+    const favorites = prefs.favorite_channels || [];
+    document.querySelectorAll('.guide-row[data-cid]').forEach(row => {
+      const cid = row.dataset.cid;
+      if (favorites.includes(cid)) {
+        row.classList.add('chan-favorite');
+      } else {
+        row.classList.remove('chan-favorite');
+      }
+    });
+  }
+
+  function syncShowFavoritesButton() {
+    const label = showingFavoritesOnly ? '⭐ Show All Channels' : '⭐ Show Favorites Only';
+    ['toggleShowFavoritesOnly', 'mobileToggleShowFavoritesOnly'].forEach(function (id) {
+      const el = document.getElementById(id);
+      if (el) el.textContent = label;
+    });
+  }
+
+  function toggleShowFavoritesOnly() {
+    showingFavoritesOnly = !showingFavoritesOnly;
+    document.body.classList.toggle('favorites-only', showingFavoritesOnly);
+    syncShowFavoritesButton();
+  }
+
+  async function addFavorite(cid) {
+    if (!cid) return;
+    const favorites = prefs.favorite_channels || [];
+    if (!favorites.includes(cid)) {
+      const next = favorites.concat([cid]);
+      await savePatch({ favorite_channels: next });
+      applyFavoriteChannels();
+    }
+    log('added favorite', cid);
+  }
+
+  async function removeFavorite(cid) {
+    if (!cid) return;
+    const next = (prefs.favorite_channels || []).filter(id => id !== cid);
+    await savePatch({ favorite_channels: next });
+    applyFavoriteChannels();
+    log('removed favorite', cid);
+  }
+
+  // ─── Channel numbers toggle ────────────────────────────────────────────────
+  function isThemeWithBuiltInChannelNumbers() {
+    return THEMES_WITH_BUILT_IN_CHANNEL_NUMBERS.some(function (theme) {
+      return document.body.classList.contains(theme);
+    });
+  }
+
+  function removeUserChannelNumbers() {
+    document.querySelectorAll('.chan-name .user-channel-number').forEach(function (el) {
+      el.remove();
+    });
+  }
+
+  function addUserChannelNumbers() {
+    var channelEls = Array.from(document.querySelectorAll('.guide-row[data-cid] .chan-name')).filter(function (el) {
+      return !el.closest('.__auto_scroll_clone');
+    });
+    removeUserChannelNumbers();
+    channelEls.forEach(function (el, idx) {
+      if (el.querySelector('.channel-number')) return;
+      var num = document.createElement('span');
+      num.className = 'user-channel-number';
+      num.textContent = CHANNEL_NUMBER_PREFIX + String(idx + 1);
+      el.insertBefore(num, el.firstChild);
+    });
+  }
+
+  function applyChannelNumbersPreference() {
+    const shouldShow = !!prefs.channel_numbers_enabled && !isThemeWithBuiltInChannelNumbers();
+    if (shouldShow) {
+      addUserChannelNumbers();
+    } else {
+      removeUserChannelNumbers();
+    }
+  }
+
+  function scheduleChannelNumbersReapply() {
+    if (channelNumberReapplyQueued) return;
+    channelNumberReapplyQueued = true;
+    var run = function () {
+      channelNumberReapplyQueued = false;
+      if (!prefs.channel_numbers_enabled || isThemeWithBuiltInChannelNumbers()) return;
+      applyChannelNumbersPreference();
+    };
+    if (typeof window.requestAnimationFrame === 'function') {
+      window.requestAnimationFrame(run);
+    } else {
+      setTimeout(run, 0);
+    }
+  }
+
+  function syncChannelNumbersButton() {
+    const hidden = isThemeWithBuiltInChannelNumbers();
+    const enabled = !!prefs.channel_numbers_enabled;
+    const label = enabled ? '🔢 Hide Channel Numbers' : '🔢 Show Channel Numbers';
+    ['toggleChannelNumbers', 'mobileToggleChannelNumbers'].forEach(function (id) {
+      const el = document.getElementById(id);
+      if (!el) return;
+      el.style.display = hidden ? 'none' : '';
+      el.textContent = label;
+    });
+  }
+
+  async function toggleChannelNumbers() {
+    if (isThemeWithBuiltInChannelNumbers()) return;
+    prefs.channel_numbers_enabled = !prefs.channel_numbers_enabled;
+    await savePatch({ channel_numbers_enabled: !!prefs.channel_numbers_enabled });
+    syncChannelNumbersButton();
+    applyChannelNumbersPreference();
   }
 
   // ─── Auto-load channel ────────────────────────────────────────────────────
@@ -218,34 +343,50 @@
       return d;
     }
 
-    menu.appendChild(item('ctxPlay',      '▶  Play Channel'));
-    menu.appendChild(item('ctxAutoLoad',  'Set as Auto-Load Channel'));
-    menu.appendChild(item('ctxHide',      '🙈 Hide Channel'));
-    menu.appendChild(item('ctxUnhide',    '👁  Unhide Channel'));
+    menu.appendChild(item('ctxPlay',       '▶  Play Channel'));
+    menu.appendChild(item('ctxAutoLoad',   'Set as Auto-Load Channel'));
+    menu.appendChild(item('ctxFavorite',   '⭐ Add to Favorites'));
+    menu.appendChild(item('ctxUnfavorite', '✖  Remove from Favorites'));
+    menu.appendChild(item('ctxHide',       '🙈 Hide Channel'));
+    menu.appendChild(item('ctxUnhide',     '👁  Unhide Channel'));
 
     document.body.appendChild(menu);
 
     menu.querySelector('#ctxPlay').addEventListener('click', function () {
+      const tgt = ctxTarget;
       closeCtxMenu();
-      if (!ctxTarget) return;
+      if (!tgt) return;
       if (typeof window.playChannel === 'function') {
-        window.playChannel(ctxTarget.dataset.url, ctxTarget.dataset.cid, ctxTarget.dataset.name);
+        window.playChannel(tgt.dataset.url, tgt.dataset.cid, tgt.dataset.name);
       }
     });
     menu.querySelector('#ctxAutoLoad').addEventListener('click', async function () {
+      const tgt = ctxTarget;
       closeCtxMenu();
-      if (!ctxTarget) return;
-      await savePatch({ auto_load_channel: { id: ctxTarget.dataset.cid, name: ctxTarget.dataset.name } });
+      if (!tgt) return;
+      await savePatch({ auto_load_channel: { id: tgt.dataset.cid, name: tgt.dataset.name } });
       syncAutoLoadButton();
       applyAutoLoadMarker();
     });
     menu.querySelector('#ctxHide').addEventListener('click', async function () {
+      const cid = ctxTarget ? ctxTarget.dataset.cid : null;
       closeCtxMenu();
-      if (ctxTarget) await hideChannel(ctxTarget.dataset.cid);
+      if (cid) await hideChannel(cid);
     });
     menu.querySelector('#ctxUnhide').addEventListener('click', async function () {
+      const cid = ctxTarget ? ctxTarget.dataset.cid : null;
       closeCtxMenu();
-      if (ctxTarget) await unhideChannel(ctxTarget.dataset.cid);
+      if (cid) await unhideChannel(cid);
+    });
+    menu.querySelector('#ctxFavorite').addEventListener('click', async function () {
+      const cid = ctxTarget ? ctxTarget.dataset.cid : null;
+      closeCtxMenu();
+      if (cid) await addFavorite(cid);
+    });
+    menu.querySelector('#ctxUnfavorite').addEventListener('click', async function () {
+      const cid = ctxTarget ? ctxTarget.dataset.cid : null;
+      closeCtxMenu();
+      if (cid) await removeFavorite(cid);
     });
 
     return menu;
@@ -255,13 +396,16 @@
     if (!ctxMenu) ctxMenu = createContextMenu();
     ctxTarget = chanEl;
     const cid = chanEl.dataset.cid;
-    const isHidden = (prefs.hidden_channels || []).includes(cid);
-    ctxMenu.querySelector('#ctxHide').style.display   = isHidden ? 'none' : '';
-    ctxMenu.querySelector('#ctxUnhide').style.display = isHidden ? ''     : 'none';
+    const isHidden   = (prefs.hidden_channels   || []).includes(cid);
+    const isFavorite = (prefs.favorite_channels || []).includes(cid);
+    ctxMenu.querySelector('#ctxHide').style.display        = isHidden   ? 'none' : '';
+    ctxMenu.querySelector('#ctxUnhide').style.display      = isHidden   ? ''     : 'none';
+    ctxMenu.querySelector('#ctxFavorite').style.display    = isFavorite ? 'none' : '';
+    ctxMenu.querySelector('#ctxUnfavorite').style.display  = isFavorite ? ''     : 'none';
 
     ctxMenu.style.display = 'block';
     // Keep within viewport
-    const menuW = 210, menuH = 140;
+    const menuW = 210, menuH = 180;
     const left = (x + menuW > window.innerWidth)  ? (x - menuW) : x;
     const top  = (y + menuH > window.innerHeight) ? (y - menuH) : y;
     ctxMenu.style.left = left + 'px';
@@ -276,9 +420,13 @@
   // ─── Init ──────────────────────────────────────────────────────────────────
   function init() {
     applyHiddenChannels();
+    applyFavoriteChannels();
     applyAutoLoadMarker();
     syncAutoLoadButton();
     syncShowHiddenButton();
+    syncShowFavoritesButton();
+    syncChannelNumbersButton();
+    applyChannelNumbersPreference();
     scheduleAutoLoad();
 
     // Wire Settings-menu buttons (desktop + mobile, present in _header.html)
@@ -286,12 +434,29 @@
       const el = document.getElementById(id);
       if (el) el.addEventListener('click', function (e) { e.preventDefault(); fn(); });
     }
-    wire('setAutoLoadChannel',       setAutoLoad);
-    wire('clearAutoLoadChannel',     clearAutoLoad);
-    wire('toggleShowHidden',         toggleShowHidden);
-    wire('mobileSetAutoLoadChannel', setAutoLoad);
-    wire('mobileClearAutoLoadChannel', clearAutoLoad);
-    wire('mobileToggleShowHidden',   toggleShowHidden);
+    wire('setAutoLoadChannel',           setAutoLoad);
+    wire('clearAutoLoadChannel',         clearAutoLoad);
+    wire('toggleShowHidden',             toggleShowHidden);
+    wire('toggleShowFavoritesOnly',      toggleShowFavoritesOnly);
+    wire('mobileSetAutoLoadChannel',     setAutoLoad);
+    wire('mobileClearAutoLoadChannel',   clearAutoLoad);
+    wire('mobileToggleShowHidden',       toggleShowHidden);
+    wire('mobileToggleShowFavoritesOnly', toggleShowFavoritesOnly);
+    wire('toggleChannelNumbers',         toggleChannelNumbers);
+    wire('mobileToggleChannelNumbers',   toggleChannelNumbers);
+
+    window.addEventListener('theme:applied', function () {
+      syncChannelNumbersButton();
+      applyChannelNumbersPreference();
+    });
+
+    var guideOuter = document.getElementById('guideOuter');
+    if (guideOuter && typeof MutationObserver === 'function') {
+      var rowObserver = new MutationObserver(function () {
+        scheduleChannelNumbersReapply();
+      });
+      rowObserver.observe(guideOuter, { childList: true });
+    }
 
     // Right-click context menu on channel names
     document.querySelectorAll('.chan-name').forEach(function (el) {
@@ -314,12 +479,16 @@
   // ─── Public API ───────────────────────────────────────────────────────────
   window.__userPrefs = {
     get prefs() { return prefs; },
-    save:             savePatch,
-    setAutoLoad:      setAutoLoad,
-    clearAutoLoad:    clearAutoLoad,
-    toggleShowHidden: toggleShowHidden,
-    hideChannel:      hideChannel,
-    unhideChannel:    unhideChannel
+    save:                  savePatch,
+    setAutoLoad:           setAutoLoad,
+    clearAutoLoad:         clearAutoLoad,
+    toggleShowHidden:      toggleShowHidden,
+    hideChannel:           hideChannel,
+    unhideChannel:         unhideChannel,
+    addFavorite:           addFavorite,
+    removeFavorite:        removeFavorite,
+    toggleShowFavoritesOnly: toggleShowFavoritesOnly,
+    toggleChannelNumbers:  toggleChannelNumbers
   };
 
   // Bootstrap when DOM is ready

--- a/templates/_header.html
+++ b/templates/_header.html
@@ -7,6 +7,9 @@
   <div class="links" role="navigation" aria-label="Main navigation">
       <span style="margin-right:20px; font-weight:bold;">Active Tuner: {{ current_tuner }}</span>
       <a href="{{ url_for('guide') }}">HOME</a>
+      {% if request.endpoint == 'guide' %}
+      <a href="#" id="guideSearchToggle" role="button" aria-expanded="false" aria-controls="guideSearchPanel">SEARCH</a>
+      {% endif %}
 
       <div class="dropdown" id="settingsMenu">
           <button class="dropbtn">SETTINGS ▾</button>
@@ -36,6 +39,8 @@
                       <li><a href="#" id="setAutoLoadChannel">Auto Load Channel</a></li>
                       <li><a href="#" id="clearAutoLoadChannel" style="display:none">Clear Auto Load</a></li>
                       <li><a href="#" id="toggleShowHidden">👁 Show Hidden Channels</a></li>
+                      <li><a href="#" id="toggleShowFavoritesOnly">⭐ Show Favorites Only</a></li>
+                      <li><a href="#" id="toggleChannelNumbers" style="display:none">🔢 Show Channel Numbers</a></li>
                     </ul>
                   </li>
                   {% endif %}
@@ -124,6 +129,9 @@
 
     <ul class="mobile-links" role="menubar">
       <li role="none"><a role="menuitem" href="{{ url_for('guide') }}">HOME</a></li>
+      {% if request.endpoint == 'guide' %}
+      <li role="none"><a role="menuitem" href="#" id="mobileGuideSearchToggle" aria-expanded="false" aria-controls="guideSearchPanel">SEARCH</a></li>
+      {% endif %}
 
       <!-- Settings collapsible -->
       <li class="mobile-submenu" role="none">
@@ -191,6 +199,8 @@
                   <li role="none"><a role="menuitem" href="#" id="mobileSetAutoLoadChannel">Auto Load Channel</a></li>
                   <li role="none"><a role="menuitem" href="#" id="mobileClearAutoLoadChannel" style="display:none">Clear Auto Load</a></li>
                   <li role="none"><a role="menuitem" href="#" id="mobileToggleShowHidden">👁 Show Hidden Channels</a></li>
+                  <li role="none"><a role="menuitem" href="#" id="mobileToggleShowFavoritesOnly">⭐ Show Favorites Only</a></li>
+                  <li role="none"><a role="menuitem" href="#" id="mobileToggleChannelNumbers" style="display:none">🔢 Show Channel Numbers</a></li>
                 </ul>
               </li>
               {% endif %}

--- a/templates/guide.html
+++ b/templates/guide.html
@@ -151,6 +151,13 @@
         height: 100% !important;
         object-fit: cover;
     }
+    /* Native fullscreen entered from the video control bar should letterbox instead of crop. */
+    #video:fullscreen,
+    #video:-webkit-full-screen {
+        width: 100vw !important;
+        height: 100vh !important;
+        object-fit: contain !important;
+    }
     /* Maintain 16:9 aspect ratio for the virtual overlay root in native fullscreen
        so channel_mix and other overlay-only channels are not stretched.
        Width is capped at 1280px (max 720px tall) to match standalone-page letterboxing.
@@ -211,6 +218,24 @@
     }
     #vcFsOverlayMute:hover { background: rgba(0, 0, 0, 0.95); }
     #vcFsOverlayMute.vc-fs-overlay-close-fade { opacity: 0; pointer-events: none; }
+    #vcFsOverlayInfo {
+        position: absolute;
+        top: 12px;
+        right: 128px;
+        z-index: 9110;
+        background: rgba(0, 0, 0, 0.7);
+        color: #fff;
+        border: none;
+        border-radius: 4px;
+        padding: 8px 14px;
+        font-size: 18px;
+        line-height: 1;
+        cursor: pointer;
+        transition: background 0.15s, opacity 0.4s;
+        opacity: 1;
+    }
+    #vcFsOverlayInfo:hover { background: rgba(0, 0, 0, 0.95); }
+    #vcFsOverlayInfo.vc-fs-overlay-close-fade { opacity: 0; pointer-events: none; }
     /* Transparent layer that captures mouse events when the iframe would swallow them */
     #vcFsMouseTrap {
         position: absolute;
@@ -220,6 +245,151 @@
         cursor: default;
     }
     #vcFsMouseTrap.active { pointer-events: auto; }
+    /* ── Channel Info Banner ────────────────────────────────────────────────── */
+    .channel-info-banner {
+        position: absolute;
+        bottom: 0;
+        left: 0;
+        right: 0;
+        z-index: 30;
+        background: linear-gradient(to bottom, transparent 0%, rgba(0,0,0,0.88) 40%, rgba(0,0,0,0.96) 100%);
+        padding: 24px 14px 10px;
+        pointer-events: none;
+        transform: translateY(0);
+        opacity: 1;
+        transition: transform 0.3s ease, opacity 0.3s ease;
+    }
+    .channel-info-banner.cib-hiding {
+        transform: translateY(100%);
+        opacity: 0;
+    }
+    .cib-inner {
+        display: flex;
+        align-items: center;
+        gap: 12px;
+        color: #fff;
+        font-family: Arial, Helvetica, sans-serif;
+    }
+    .cib-logo-wrap { flex-shrink: 0; }
+    .cib-logo {
+        width: 44px;
+        height: 44px;
+        object-fit: contain;
+        border-radius: 4px;
+        background: rgba(255,255,255,0.08);
+        display: block;
+    }
+    .cib-info { flex: 1; min-width: 0; }
+    .cib-title-row {
+        display: flex;
+        align-items: baseline;
+        gap: 6px;
+        margin-bottom: 4px;
+        min-width: 0;
+    }
+    .cib-chan-num {
+        font-size: 0.78em;
+        color: #ffd700;
+        font-weight: 700;
+        flex-shrink: 0;
+        letter-spacing: 0.03em;
+    }
+    .cib-chan-name {
+        font-size: 0.78em;
+        font-weight: 700;
+        color: #9fbfff;
+        flex-shrink: 0;
+        white-space: nowrap;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        max-width: 130px;
+    }
+    .cib-prog-title {
+        font-size: 1em;
+        font-weight: 700;
+        color: #fff;
+        white-space: nowrap;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        flex: 1;
+        min-width: 0;
+    }
+    .cib-time-row {
+        display: flex;
+        align-items: center;
+        gap: 8px;
+        margin-bottom: 3px;
+    }
+    .cib-time {
+        font-size: 0.72em;
+        color: #bbb;
+        flex-shrink: 0;
+        white-space: nowrap;
+    }
+    .cib-progress-wrap {
+        flex: 1;
+        height: 3px;
+        background: rgba(255,255,255,0.18);
+        border-radius: 2px;
+        overflow: hidden;
+    }
+    .cib-progress-bar {
+        height: 100%;
+        background: #4a8fff;
+        border-radius: 2px;
+        transition: width 1s linear;
+    }
+    .cib-remaining {
+        font-size: 0.68em;
+        color: #aaa;
+        flex-shrink: 0;
+        white-space: nowrap;
+    }
+    .cib-desc {
+        font-size: 0.73em;
+        color: #ccc;
+        white-space: nowrap;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        line-height: 1.3;
+    }
+    /* Info toggle button – bottom-left of video player */
+    .cib-toggle-btn {
+        bottom: 8px !important;
+        top: auto !important;
+        right: auto !important;
+        left: 8px !important;
+        font-size: 14px !important;
+    }
+    .guide-filter-panel {
+        display: none;
+        align-items: center;
+        gap: 8px;
+        padding: 6px 10px;
+        border-bottom: 1px solid var(--timebar-border, rgba(0,0,0,0.12));
+        background: var(--timebar-bg, rgba(255,255,255,0.95));
+        color: var(--timebar-color, inherit);
+    }
+    .guide-filter-panel.is-open { display: flex; }
+    .guide-filter-panel label {
+        font-size: 12px;
+        opacity: 0.85;
+        white-space: nowrap;
+    }
+    .guide-filter-panel input,
+    .guide-filter-panel select {
+        min-height: 30px;
+        padding: 4px 8px;
+        background: var(--chan-col-bg, #fff);
+        color: inherit;
+        border: 1px solid var(--timebar-border, rgba(0,0,0,0.2));
+    }
+    .guide-filter-panel input { flex: 1; min-width: 180px; }
+    .guide-row.chan-search-hidden { display: none !important; }
+    #vcFsOverlay .channel-info-banner {
+        z-index: 9109;
+        padding: 64px 20px 16px;
+    }
     </style>
     {% if overlay_appearance.text_color or overlay_appearance.bg_color %}
     <style>
@@ -234,6 +404,15 @@
 <div id="appZoomRoot">
 {% include '_header.html' %}
 
+<div id="guideSearchPanel" class="guide-filter-panel" role="search" hidden>
+    <label for="guideSearchInput">Search</label>
+    <input id="guideSearchInput" type="search" placeholder="Channel, program, type…" autocomplete="off" aria-label="Search guide by channel, program, or type">
+    <label for="guideTypeFilter">Type</label>
+    <select id="guideTypeFilter" aria-label="Filter guide by type">
+        <option value="">All</option>
+    </select>
+</div>
+
 <!-- Player row: summary left, video right -->
 <div class="player" id="playerRow">
     <div class="summary" id="summary">
@@ -244,7 +423,31 @@
         <video id="video" controls playsinline preload="metadata" tabindex="0"></video>
         <button id="unmuteBtn" class="unmute-btn" hidden aria-label="Unmute video" title="Click to unmute">🔇 Unmute</button>
         <button id="vcMuteBtn" class="vc-fs-btn" hidden aria-label="Mute virtual channel" title="Mute">🔇</button>
-        <button id="vcFsBtn" class="vc-fs-btn" hidden aria-label="Toggle virtual channel fullscreen" title="Fullscreen">⛶</button>
+        <button id="vcFsBtn" class="vc-fs-btn" hidden aria-label="Toggle fullscreen" title="Fullscreen">⛶</button>
+        <button id="chanInfoBtn" class="vc-fs-btn cib-toggle-btn" hidden aria-label="Toggle channel info" title="Channel Info">ℹ</button>
+        <!-- Channel Info Banner: slides up from bottom of the video player on channel select -->
+        <div id="channelInfoBanner" class="channel-info-banner" aria-live="polite" aria-atomic="true" style="display:none;">
+            <div class="cib-inner">
+                <div class="cib-logo-wrap">
+                    <img id="cibLogo" class="cib-logo" src="" alt="Channel logo" onerror="this.style.display='none'">
+                </div>
+                <div class="cib-info">
+                    <div class="cib-title-row">
+                        <span id="cibChanNum" class="cib-chan-num"></span>
+                        <span id="cibChanName" class="cib-chan-name"></span>
+                        <span id="cibProgTitle" class="cib-prog-title"></span>
+                    </div>
+                    <div class="cib-time-row">
+                        <span id="cibTime" class="cib-time"></span>
+                        <div class="cib-progress-wrap">
+                            <div id="cibProgress" class="cib-progress-bar"></div>
+                        </div>
+                        <span id="cibRemaining" class="cib-remaining"></span>
+                    </div>
+                    <div id="cibDesc" class="cib-desc"></div>
+                </div>
+            </div>
+        </div>
         <div id="virtual-overlay-root" class="hidden" aria-hidden="true"></div>
     </div>
 </div>
@@ -283,6 +486,7 @@
                  data-cid="{{ ch.tvg_id }}"
                  data-name="{{ ch.name|e }}"
                  data-logo="{{ ch.logo }}"
+                 data-chan-num="{{ ch.tvg_chno if ch.tvg_chno else loop.index }}"
                  {% if ch.is_virtual %}
                  data-is-virtual="true"
                  data-loop-asset="{{ ch.loop_asset }}"
@@ -326,10 +530,12 @@
                             data-stop="{{ prog.stop.isoformat() }}"
                             data-title="{{ prog.title }}"
                             data-desc="{{ prog.desc }}"
-                            data-icon="{{ prog.icon if prog.icon else '' }}">
-                            {{ prog.title }}
-                        </div>
-                    {% endif %}
+                                data-icon="{{ prog.icon if prog.icon else '' }}"
+                                data-categories="{{ (prog.categories or [])|join(' | ') }}"
+                                data-colors="{{ (prog.colors or [])|join(' | ') }}">
+                                {{ prog.title }}
+                            </div>
+                        {% endif %}
                 {% endfor %}
             {% endif %}
             </div>
@@ -416,6 +622,8 @@ function _scheduleVcFsHide(delay) {
         if (btn && !btn.hidden) btn.classList.add('vc-fs-btn-fade');
         const mb = document.getElementById('vcMuteBtn');
         if (mb && !mb.hidden) mb.classList.add('vc-fs-btn-fade');
+        const ib = document.getElementById('chanInfoBtn');
+        if (ib && !ib.hidden) ib.classList.add('vc-fs-btn-fade');
     }, delay);
 }
 
@@ -426,6 +634,8 @@ function _scheduleOverlayCloseFade(delay) {
         if (cb) cb.classList.add('vc-fs-overlay-close-fade');
         const mb = document.getElementById('vcFsOverlayMute');
         if (mb) mb.classList.add('vc-fs-overlay-close-fade');
+        const ib = document.getElementById('vcFsOverlayInfo');
+        if (ib && !ib.hidden) ib.classList.add('vc-fs-overlay-close-fade');
         const trap = document.getElementById('vcFsMouseTrap');
         if (trap) trap.classList.add('active');
     }, delay);
@@ -438,6 +648,8 @@ function _showOverlayClose() {
     if (cb) cb.classList.remove('vc-fs-overlay-close-fade');
     const mb = document.getElementById('vcFsOverlayMute');
     if (mb) mb.classList.remove('vc-fs-overlay-close-fade');
+    const ib = document.getElementById('vcFsOverlayInfo');
+    if (ib && !ib.hidden) ib.classList.remove('vc-fs-overlay-close-fade');
     _scheduleOverlayCloseFade(1500);
 }
 
@@ -447,6 +659,8 @@ function _cancelOverlayCloseFade() {
     if (cb) cb.classList.remove('vc-fs-overlay-close-fade');
     const mb = document.getElementById('vcFsOverlayMute');
     if (mb) mb.classList.remove('vc-fs-overlay-close-fade');
+    const ib = document.getElementById('vcFsOverlayInfo');
+    if (ib) ib.classList.remove('vc-fs-overlay-close-fade');
     const trap = document.getElementById('vcFsMouseTrap');
     if (trap) trap.classList.remove('active');
 }
@@ -475,8 +689,18 @@ function showVcFsBtn() {
     if (!btn) return;
     btn.hidden = false;
     btn.classList.remove('vc-fs-btn-fade');
+    btn.title = 'Fullscreen';
+    btn.setAttribute('aria-label', 'Toggle fullscreen');
     const mb = document.getElementById('vcMuteBtn');
-    if (mb) { mb.hidden = false; mb.classList.remove('vc-fs-btn-fade'); }
+    if (mb) {
+        mb.hidden = !_vcCurrentOverlayType;
+        mb.classList.remove('vc-fs-btn-fade');
+    }
+    const ib = document.getElementById('chanInfoBtn');
+    if (ib) {
+        ib.hidden = !currentChannelId;
+        ib.classList.remove('vc-fs-btn-fade');
+    }
     _updateVcMuteBtn();
     _scheduleVcFsHide(3500);
 }
@@ -490,12 +714,19 @@ function hideVcFsBtn() {
     }
     const mb = document.getElementById('vcMuteBtn');
     if (mb) { mb.hidden = true; mb.classList.remove('vc-fs-btn-fade'); }
+    const ib = document.getElementById('chanInfoBtn');
+    if (ib) { ib.hidden = true; ib.classList.remove('vc-fs-btn-fade'); }
     // Close iframe overlay if active when switching away from a virtual channel.
     const overlay = document.getElementById('vcFsOverlay');
     const iframe  = document.getElementById('vcFsIframe');
     if (overlay && !overlay.classList.contains('hidden')) {
         overlay.classList.add('hidden');
         if (iframe) iframe.src = '';
+    }
+    const overlayInfo = document.getElementById('vcFsOverlayInfo');
+    if (overlayInfo) {
+        overlayInfo.hidden = true;
+        overlayInfo.classList.remove('vc-fs-overlay-close-fade');
     }
     // Exit fullscreen if the user switches to a normal channel while fullscreen.
     _exitVcFs();
@@ -565,10 +796,18 @@ document.addEventListener('DOMContentLoaded', function () {
         if (!overlay || !iframe) return;
         iframe.src = pageUrl;
         overlay.classList.remove('hidden');
+        const infoBtn = document.getElementById('vcFsOverlayInfo');
+        if (infoBtn) {
+            infoBtn.hidden = !currentChannelId;
+            infoBtn.classList.remove('vc-fs-overlay-close-fade');
+        }
         btn.textContent = '✕';
         btn.title = 'Exit fullscreen';
         btn.setAttribute('aria-label', 'Exit fullscreen');
         _showOverlayClose();
+        if (currentChannelId && typeof window.showChannelInfoBanner === 'function') {
+            window.showChannelInfoBanner(currentChannelId, (window.currentChannelMeta && window.currentChannelMeta.name) || '');
+        }
         if (_vcCurrentOverlayType === 'channel_mix') { _startCmFsPoll(); }
         // Request true fullscreen on the overlay div so the browser chrome hides
         const req = overlay.requestFullscreen || overlay.webkitRequestFullscreen || overlay.mozRequestFullscreen;
@@ -585,9 +824,11 @@ document.addEventListener('DOMContentLoaded', function () {
         const iframe  = document.getElementById('vcFsIframe');
         if (overlay) overlay.classList.add('hidden');
         if (iframe) iframe.src = '';  // stop network activity in iframe
+        const infoBtn = document.getElementById('vcFsOverlayInfo');
+        if (infoBtn) infoBtn.hidden = true;
         btn.textContent = '⛶';
         btn.title = 'Fullscreen';
-        btn.setAttribute('aria-label', 'Toggle virtual channel fullscreen');
+        btn.setAttribute('aria-label', 'Toggle fullscreen');
         if (fsElement()) {
             (document.exitFullscreen || document.webkitExitFullscreen || function(){}).call(document);
         }
@@ -613,6 +854,9 @@ document.addEventListener('DOMContentLoaded', function () {
                 openVcFsOverlay(pageUrl);
             } else {
                 // Fallback for overlay types without a standalone page
+                if (currentChannelId && typeof window.showChannelInfoBanner === 'function') {
+                    window.showChannelInfoBanner(currentChannelId, (window.currentChannelMeta && window.currentChannelMeta.name) || '');
+                }
                 const req = wrap.requestFullscreen || wrap.webkitRequestFullscreen || wrap.mozRequestFullscreen;
                 if (req) {
                     const p = req.call(wrap);
@@ -627,6 +871,12 @@ document.addEventListener('DOMContentLoaded', function () {
 
     const overlayMuteBtn = document.getElementById('vcFsOverlayMute');
     if (overlayMuteBtn) overlayMuteBtn.addEventListener('click', _toggleVcMute);
+
+    const overlayInfoBtn = document.getElementById('vcFsOverlayInfo');
+    if (overlayInfoBtn) overlayInfoBtn.addEventListener('click', function (e) {
+        e.stopPropagation();
+        if (typeof window.toggleChannelInfoBanner === 'function') window.toggleChannelInfoBanner();
+    });
 
     const wrapMuteBtn = document.getElementById('vcMuteBtn');
     if (wrapMuteBtn) wrapMuteBtn.addEventListener('click', _toggleVcMute);
@@ -659,16 +909,18 @@ document.addEventListener('DOMContentLoaded', function () {
             const iframe  = document.getElementById('vcFsIframe');
             if (overlay) overlay.classList.add('hidden');
             if (iframe) iframe.src = '';
+            const infoBtn = document.getElementById('vcFsOverlayInfo');
+            if (infoBtn) infoBtn.hidden = true;
             btn.textContent = '⛶';
             btn.title = 'Fullscreen';
-            btn.setAttribute('aria-label', 'Toggle virtual channel fullscreen');
+            btn.setAttribute('aria-label', 'Toggle fullscreen');
             return;
         }
         // Wrapper-based fullscreen (fallback for 'status' and future overlay types)
         const isFs = fsEl === wrap;
         btn.textContent = isFs ? '✕' : '⛶';
         btn.title = isFs ? 'Exit fullscreen' : 'Fullscreen';
-        btn.setAttribute('aria-label', isFs ? 'Exit fullscreen' : 'Toggle virtual channel fullscreen');
+        btn.setAttribute('aria-label', isFs ? 'Exit fullscreen' : 'Toggle fullscreen');
     }
 
     document.addEventListener('fullscreenchange', onFsChange);
@@ -691,18 +943,22 @@ document.addEventListener('DOMContentLoaded', function () {
     // Auto-hide: show button on mouse activity over the player wrap, hide after idle
     if (wrap) {
         wrap.addEventListener('mousemove', function () {
-            if (!btn.hidden) {
+            const ib = document.getElementById('chanInfoBtn');
+            // Activate for virtual-channel controls (vcFsBtn visible) OR whenever ℹ is active
+            if (!btn.hidden || (ib && !ib.hidden)) {
                 const now = Date.now();
                 if (now - _vcFsLastMove < 250) return;
                 _vcFsLastMove = now;
-                btn.classList.remove('vc-fs-btn-fade');
+                if (!btn.hidden) btn.classList.remove('vc-fs-btn-fade');
                 const mb = document.getElementById('vcMuteBtn');
                 if (mb && !mb.hidden) mb.classList.remove('vc-fs-btn-fade');
+                if (ib && !ib.hidden) ib.classList.remove('vc-fs-btn-fade');
                 _scheduleVcFsHide(1500);
             }
         });
         wrap.addEventListener('mouseleave', function () {
-            if (!btn.hidden) _scheduleVcFsHide(1500);
+            const ib = document.getElementById('chanInfoBtn');
+            if (!btn.hidden || (ib && !ib.hidden)) _scheduleVcFsHide(1500);
         });
     }
 
@@ -737,10 +993,18 @@ function getDisplayZoom() {
 
 function playChannel(url, cid, name) {
     const video = document.getElementById('video');
+    // Save the current channel as "last channel" before switching (skip if it's the same channel)
+    if (currentChannelId && currentChannelId !== cid && window.currentChannelMeta) {
+        window.lastChannelMeta = Object.assign({}, window.currentChannelMeta);
+    }
     currentChannelId = cid;
     // Expose currently-playing channel for user-prefs.js (auto-load / context menu)
     window.currentChannelMeta = { id: cid, name: name, url: url };
     updateSummary(cid, name);
+    // Show the channel info banner on tune-in
+    if (typeof window.showChannelInfoBanner === 'function') {
+        window.showChannelInfoBanner(cid, name);
+    }
 
     fetch("/play_channel", {
         method: "POST",
@@ -781,6 +1045,8 @@ function playChannel(url, cid, name) {
 
     // Ensure any mute applied by a previous virtual channel is cleared.
     _vcCurrentOverlayType = '';
+    // Normal channels use the native video player's built-in fullscreen button;
+    // keep virtual-channel-only controls hidden.
     hideVcFsBtn();
     video.muted = false;
 
@@ -810,6 +1076,15 @@ function playChannel(url, cid, name) {
         tryPlay();
     }
 }
+
+/**
+ * Return to the previously watched channel ("Last Channel" feature).
+ * Exposed globally so channel-number-entry.js (and any future module) can trigger it.
+ */
+window.returnToLastChannel = function () {
+    if (!window.lastChannelMeta) return;
+    playChannel(window.lastChannelMeta.url, window.lastChannelMeta.id, window.lastChannelMeta.name);
+};
 
 function escapeHTML(str) {
     return String(str)
@@ -867,6 +1142,266 @@ function updateSummary(cid, fallbackName) {
       window.dispatchEvent(new Event('resize'));
     });
 }
+
+// ── Channel Info Banner ───────────────────────────────────────────────────────
+(function () {
+    'use strict';
+
+    var _cibHideTimer = null;
+    var _cibVisible = false;
+    var _cibProgressTimer = null;
+    var _CIB_AUTODISMISS_MS = 6000;
+    var _BANNERS = [
+        {
+            bannerId: 'channelInfoBanner',
+            buttonId: 'chanInfoBtn',
+            logoId: 'cibLogo',
+            chanNumId: 'cibChanNum',
+            chanNameId: 'cibChanName',
+            progTitleId: 'cibProgTitle',
+            timeId: 'cibTime',
+            progressId: 'cibProgress',
+            remainingId: 'cibRemaining',
+            descId: 'cibDesc'
+        },
+        {
+            bannerId: 'vcFsChannelInfoBanner',
+            buttonId: 'vcFsOverlayInfo',
+            logoId: 'vcFsCibLogo',
+            chanNumId: 'vcFsCibChanNum',
+            chanNameId: 'vcFsCibChanName',
+            progTitleId: 'vcFsCibProgTitle',
+            timeId: 'vcFsCibTime',
+            progressId: 'vcFsCibProgress',
+            remainingId: 'vcFsCibRemaining',
+            descId: 'vcFsCibDesc'
+        }
+    ];
+
+    function _fmt(ms) {
+        var total = Math.max(0, Math.round(ms / 60000));
+        if (total < 1) return '< 1 min left';
+        if (total === 1) return '1 min left';
+        return total + ' min left';
+    }
+
+    function _fmtTime(d) {
+        return d.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' });
+    }
+
+    function _isFsOverlayActive() {
+        var overlay = document.getElementById('vcFsOverlay');
+        return !!(overlay && !overlay.classList.contains('hidden'));
+    }
+
+    function _activeBannerConfigs() {
+        return _BANNERS.filter(function (cfg) {
+            return cfg.bannerId === 'channelInfoBanner' || _isFsOverlayActive();
+        });
+    }
+
+    function _bannerEl(cfg, key) {
+        return document.getElementById(cfg[key]);
+    }
+
+    function _applyBannerData(cfg, data) {
+        var banner = _bannerEl(cfg, 'bannerId');
+        if (!banner) return;
+
+        var logoEl = _bannerEl(cfg, 'logoId');
+        if (logoEl) {
+            if (data.logo) {
+                logoEl.src = data.logo;
+                logoEl.alt = data.chanName;
+                logoEl.style.display = '';
+            } else {
+                logoEl.src = '';
+                logoEl.style.display = 'none';
+            }
+        }
+
+        var numEl = _bannerEl(cfg, 'chanNumId');
+        if (numEl) numEl.textContent = data.chanNum ? 'CH ' + data.chanNum : '';
+
+        var nameEl = _bannerEl(cfg, 'chanNameId');
+        if (nameEl) nameEl.textContent = data.chanName;
+
+        var titleEl = _bannerEl(cfg, 'progTitleId');
+        if (titleEl) titleEl.textContent = data.progTitle || data.chanName;
+
+        var timeEl = _bannerEl(cfg, 'timeId');
+        var progressEl = _bannerEl(cfg, 'progressId');
+        var remainingEl = _bannerEl(cfg, 'remainingId');
+        var descEl = _bannerEl(cfg, 'descId');
+
+        if (data.progStart && data.progStop) {
+            if (timeEl) timeEl.textContent = _fmtTime(data.progStart) + ' – ' + _fmtTime(data.progStop);
+            if (progressEl) progressEl.style.width = data.progressPct + '%';
+            if (remainingEl) remainingEl.textContent = _fmt(data.progStop - data.now);
+        } else {
+            if (timeEl) timeEl.textContent = '';
+            if (progressEl) progressEl.style.width = '0%';
+            if (remainingEl) remainingEl.textContent = '';
+        }
+
+        if (descEl) descEl.textContent = data.progDesc;
+
+        banner.style.display = '';
+        // Force a reflow before removing cib-hiding so the slide/fade animation
+        // has a concrete starting state and reliably plays on every show.
+        banner.offsetHeight; // eslint-disable-line no-unused-expressions
+        banner.classList.remove('cib-hiding');
+    }
+
+    function _collectBannerData(cid, fallbackName) {
+        var escapedCid = (typeof CSS !== 'undefined' && CSS.escape)
+            ? CSS.escape(cid)
+            : cid.replace(/[^a-zA-Z0-9._-]/g, '\\$&');
+        var chanEl = document.querySelector('.chan-name[data-cid="' + escapedCid + '"]');
+        var now = new Date();
+        var row = document.querySelector('.guide-row[data-cid="' + escapedCid + '"]');
+        var progTitle = '';
+        var progDesc = '';
+        var progStart = null;
+        var progStop = null;
+
+        if (row) {
+            row.querySelectorAll('.program').forEach(function (p) {
+                var s = new Date(p.dataset.start);
+                var e = new Date(p.dataset.stop);
+                if (s <= now && e >= now) {
+                    progTitle = p.dataset.title || '';
+                    progDesc = p.dataset.desc || '';
+                    progStart = s;
+                    progStop = e;
+                }
+            });
+        }
+
+        var progressPct = 0;
+        if (progStart && progStop) {
+            progressPct = Math.min(100, Math.max(0, ((now - progStart) / (progStop - progStart)) * 100));
+        }
+
+        return {
+            now: now,
+            logo: (chanEl && chanEl.dataset.logo) ? chanEl.dataset.logo : '',
+            chanName: (chanEl && chanEl.dataset.name) ? chanEl.dataset.name : (fallbackName || ''),
+            chanNum: (chanEl && chanEl.dataset.chanNum) ? chanEl.dataset.chanNum : '',
+            progTitle: progTitle,
+            progDesc: progDesc,
+            progStart: progStart,
+            progStop: progStop,
+            progressPct: progressPct
+        };
+    }
+
+    /**
+     * Populate and show the Channel Info Banner for the given channel/cid.
+     * Data is sourced entirely from the guide DOM so no extra fetch is needed.
+     */
+    function showBanner(cid, fallbackName) {
+        var data = _collectBannerData(cid, fallbackName);
+        _activeBannerConfigs().forEach(function (cfg) {
+            _applyBannerData(cfg, data);
+            var btn = _bannerEl(cfg, 'buttonId');
+            if (btn) {
+                btn.hidden = false;
+                if (cfg.bannerId === 'channelInfoBanner') {
+                    btn.classList.remove('vc-fs-btn-fade');
+                } else {
+                    btn.classList.remove('vc-fs-overlay-close-fade');
+                }
+            }
+        });
+        _cibVisible = true;
+        if (typeof showVcFsBtn === 'function') showVcFsBtn();
+        if (_isFsOverlayActive() && typeof _showOverlayClose === 'function') _showOverlayClose();
+
+        // Live-update the progress bar every 15 s while banner is visible
+        if (_cibProgressTimer) { clearInterval(_cibProgressTimer); _cibProgressTimer = null; }
+        if (data.progStart && data.progStop) {
+            _cibProgressTimer = setInterval(function () {
+                if (!_cibVisible) { clearInterval(_cibProgressTimer); _cibProgressTimer = null; return; }
+                var refreshed = _collectBannerData(cid, fallbackName);
+                _activeBannerConfigs().forEach(function (cfg) {
+                    var progressEl = _bannerEl(cfg, 'progressId');
+                    var remainingEl = _bannerEl(cfg, 'remainingId');
+                    if (progressEl) progressEl.style.width = refreshed.progressPct + '%';
+                    if (remainingEl) remainingEl.textContent = refreshed.progStop ? _fmt(refreshed.progStop - refreshed.now) : '';
+                });
+            }, 15000);
+        }
+
+        // Auto-dismiss
+        _scheduleDismiss();
+    }
+
+    function hideBanner() {
+        _cancelDismiss();
+        if (_cibProgressTimer) { clearInterval(_cibProgressTimer); _cibProgressTimer = null; }
+        if (!_cibVisible) return;
+        _BANNERS.forEach(function (cfg) {
+            var banner = _bannerEl(cfg, 'bannerId');
+            if (!banner) return;
+            banner.classList.add('cib-hiding');
+        });
+        _cibVisible = false;
+        // After transition completes, hide from layout
+        setTimeout(function () {
+            if (_cibVisible) return;
+            _BANNERS.forEach(function (cfg) {
+                var banner = _bannerEl(cfg, 'bannerId');
+                if (banner) banner.style.display = 'none';
+            });
+        }, 350);
+    }
+
+    function toggleBanner() {
+        if (_cibVisible) {
+            hideBanner();
+        } else if (window._cibLastCid) {
+            showBanner(window._cibLastCid, window._cibLastName);
+        }
+    }
+
+    function _scheduleDismiss() {
+        _cancelDismiss();
+        _cibHideTimer = setTimeout(hideBanner, _CIB_AUTODISMISS_MS);
+    }
+
+    function _cancelDismiss() {
+        if (_cibHideTimer) { clearTimeout(_cibHideTimer); _cibHideTimer = null; }
+    }
+
+    // Expose for guide.html channel switching
+    window.showChannelInfoBanner = function (cid, name) {
+        window._cibLastCid  = cid;
+        window._cibLastName = name;
+        showBanner(cid, name);
+    };
+    window.toggleChannelInfoBanner = toggleBanner;
+
+    // Wire the toggle button
+    document.addEventListener('DOMContentLoaded', function () {
+        var btn = document.getElementById('chanInfoBtn');
+        if (btn) {
+            btn.addEventListener('click', function (e) {
+                e.stopPropagation();
+                toggleBanner();
+            });
+        }
+
+        // Keyboard shortcut: 'i' key when focus is not in an input
+        document.addEventListener('keydown', function (e) {
+            if (e.key.toLowerCase() !== 'i') return;
+            var tag = (document.activeElement || {}).tagName || '';
+            if (tag === 'INPUT' || tag === 'TEXTAREA' || tag === 'SELECT') return;
+            if (e.ctrlKey || e.metaKey || e.altKey) return;
+            toggleBanner();
+        });
+    });
+})();
 
 /* Fixed time header function kept (unchanged behavior) */
 function createOrUpdateFixedTimeBar(){
@@ -1026,6 +1561,135 @@ function updateNowLine(){
     } catch(e){ console.debug('updateNowLine err', e); }
 }
 
+function normalizeFilterToken(value) {
+    return (value || '').trim().toLowerCase();
+}
+
+function collectGuideRowTypes(row) {
+    const types = new Set();
+    const group = (row.dataset.group || '').trim();
+    if (group) types.add(group);
+    const chanEl = row.querySelector('.chan-name');
+    if (chanEl && chanEl.dataset.isVirtual === 'true') types.add('virtual');
+    row.querySelectorAll('.program').forEach(prog => {
+        (prog.dataset.categories || '').split(' | ').forEach(function (cat) {
+            const cleaned = cat.trim();
+            if (cleaned) types.add(cleaned);
+        });
+    });
+    return Array.from(types);
+}
+
+function initGuideSearchFilter() {
+    const panel = document.getElementById('guideSearchPanel');
+    const searchInput = document.getElementById('guideSearchInput');
+    const typeFilter = document.getElementById('guideTypeFilter');
+    const desktopToggle = document.getElementById('guideSearchToggle');
+    const mobileToggle = document.getElementById('mobileGuideSearchToggle');
+    if (!panel || !searchInput || !typeFilter) return;
+
+    const rows = Array.from(document.querySelectorAll('.guide-row[data-cid]'));
+    const allTypes = new Set();
+
+    rows.forEach(function (row) {
+        const chanEl = row.querySelector('.chan-name');
+        const types = collectGuideRowTypes(row);
+        types.forEach(function (t) { allTypes.add(t); });
+
+        const searchChunks = [
+            chanEl ? (chanEl.dataset.name || '') : '',
+            row.dataset.group || '',
+            types.join(' '),
+        ];
+        row.querySelectorAll('.program').forEach(function (prog) {
+            searchChunks.push(
+                prog.dataset.title || '',
+                prog.dataset.desc || '',
+                prog.dataset.categories || '',
+                prog.dataset.colors || ''
+            );
+        });
+
+        row.dataset.filterText = normalizeFilterToken(searchChunks.join(' '));
+        row.dataset.filterTypes = types.map(normalizeFilterToken).filter(Boolean).join('|');
+    });
+
+    Array.from(allTypes)
+        .sort(function (a, b) { return a.localeCompare(b); })
+        .forEach(function (typeName) {
+            const opt = document.createElement('option');
+            opt.value = normalizeFilterToken(typeName);
+            opt.textContent = typeName;
+            typeFilter.appendChild(opt);
+        });
+
+    function applyGuideSearchFilter() {
+        const query = normalizeFilterToken(searchInput.value);
+        const type = normalizeFilterToken(typeFilter.value);
+
+        rows.forEach(function (row) {
+            const rowText = row.dataset.filterText || '';
+            const rowTypes = (row.dataset.filterTypes || '').split('|').filter(Boolean);
+            const matchesQuery = !query || rowText.includes(query);
+            const matchesType = !type || rowTypes.includes(type);
+            row.classList.toggle('chan-search-hidden', !(matchesQuery && matchesType));
+        });
+
+        if (window.__autoScroll && typeof window.__autoScroll.recomputeLoops === 'function') {
+            window.__autoScroll.recomputeLoops();
+        }
+    }
+
+    function syncGuideSearchToggles(isOpen) {
+        [desktopToggle, mobileToggle].forEach(function (toggle) {
+            if (!toggle) return;
+            toggle.setAttribute('aria-expanded', isOpen ? 'true' : 'false');
+        });
+    }
+
+    function setGuideSearchOpen(isOpen) {
+        panel.hidden = !isOpen;
+        panel.classList.toggle('is-open', isOpen);
+        syncGuideSearchToggles(isOpen);
+
+        requestAnimationFrame(function () {
+            if (typeof createOrUpdateFixedTimeBar === 'function') createOrUpdateFixedTimeBar();
+            if (typeof updateNowLine === 'function') updateNowLine();
+        });
+
+        if (isOpen) {
+            searchInput.focus();
+            searchInput.select();
+        } else if (document.activeElement === searchInput || document.activeElement === typeFilter) {
+            searchInput.blur();
+        }
+    }
+
+    function toggleGuideSearch(event) {
+        if (event) event.preventDefault();
+        if (window.mobileNavControl && typeof window.mobileNavControl.close === 'function') {
+            window.mobileNavControl.close();
+        }
+        setGuideSearchOpen(panel.hidden);
+    }
+
+    searchInput.addEventListener('input', applyGuideSearchFilter);
+    typeFilter.addEventListener('change', applyGuideSearchFilter);
+    if (desktopToggle) desktopToggle.addEventListener('click', toggleGuideSearch);
+    if (mobileToggle) mobileToggle.addEventListener('click', toggleGuideSearch);
+    document.addEventListener('keydown', function (event) {
+        if (event.key === 'Escape' && !panel.hidden &&
+            (document.activeElement === searchInput || document.activeElement === typeFilter)) {
+            event.preventDefault();
+            setGuideSearchOpen(false);
+        }
+    });
+
+    window.toggleGuideSearchPanel = function () {
+        setGuideSearchOpen(panel.hidden);
+    };
+}
+
 /* --- Initialization and bindings --- */
 document.addEventListener("DOMContentLoaded", () => {
     const savedTheme = localStorage.getItem("theme") || "dark";
@@ -1067,6 +1731,7 @@ document.addEventListener("DOMContentLoaded", () => {
     createOrUpdateFixedTimeBar();
     if (typeof updateClock === 'function') updateClock();
     updateNowLine();
+    initGuideSearchFilter();
 
     setInterval(updateClock, 1000);
     setInterval(updateNowLine, 60000);
@@ -1573,6 +2238,9 @@ document.addEventListener('DOMContentLoaded', () => {
 <!-- Per-user channel preferences: auto-load channel, hidden channels, sizzle reels -->
 <script src="{{ url_for('static', filename='js/user-prefs.js') }}" defer></script>
 
+<!-- Channel number entry: type digits to jump directly to a channel -->
+<script src="{{ url_for('static', filename='js/channel-number-entry.js') }}" defer></script>
+
 
 
 <!-- Android / Fire / Google TV detection (keeps TV experience simple) -->
@@ -1686,7 +2354,30 @@ document.addEventListener('DOMContentLoaded', () => {
      playing in the parent page (outside this iframe). -->
 <div id="vcFsOverlay" class="hidden" role="dialog" aria-modal="true" aria-label="Virtual channel fullscreen">
     <button id="vcFsOverlayMute" aria-label="Mute virtual channel" title="Mute">🔇</button>
+    <button id="vcFsOverlayInfo" hidden aria-label="Toggle channel info" title="Channel Info">ℹ</button>
     <button id="vcFsOverlayClose" aria-label="Close fullscreen">✕</button>
+    <div id="vcFsChannelInfoBanner" class="channel-info-banner cib-hiding" aria-live="polite" aria-atomic="true" style="display:none;">
+        <div class="cib-inner">
+            <div class="cib-logo-wrap">
+                <img id="vcFsCibLogo" class="cib-logo" src="" alt="Channel logo" onerror="this.style.display='none'">
+            </div>
+            <div class="cib-info">
+                <div class="cib-title-row">
+                    <span id="vcFsCibChanNum" class="cib-chan-num"></span>
+                    <span id="vcFsCibChanName" class="cib-chan-name"></span>
+                    <span id="vcFsCibProgTitle" class="cib-prog-title"></span>
+                </div>
+                <div class="cib-time-row">
+                    <span id="vcFsCibTime" class="cib-time"></span>
+                    <div class="cib-progress-wrap">
+                        <div id="vcFsCibProgress" class="cib-progress-bar"></div>
+                    </div>
+                    <span id="vcFsCibRemaining" class="cib-remaining"></span>
+                </div>
+                <div id="vcFsCibDesc" class="cib-desc"></div>
+            </div>
+        </div>
+    </div>
     <div id="vcFsMouseTrap"></div>
     <iframe id="vcFsIframe" src="" title="Virtual channel" allow="autoplay"></iframe>
 </div>

--- a/tests/test_channel_info_banner.py
+++ b/tests/test_channel_info_banner.py
@@ -1,0 +1,71 @@
+"""Tests for channel info banner markup in the guide player."""
+import os
+import sys
+
+import pytest
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+import app as app_module
+from app import app, init_db, init_tuners_db, add_user
+
+
+@pytest.fixture(autouse=True)
+def isolated_db(tmp_path, monkeypatch):
+    users_db = str(tmp_path / "users_test.db")
+    tuners_db = str(tmp_path / "tuners_test.db")
+    monkeypatch.setattr(app_module, "DATABASE", users_db)
+    monkeypatch.setattr(app_module, "TUNER_DB", tuners_db)
+    init_db()
+    init_tuners_db()
+    add_user("admin", "adminpass")
+    yield
+
+
+@pytest.fixture()
+def client(isolated_db):
+    app.config["TESTING"] = True
+    with app.test_client() as c:
+        yield c
+
+
+def login(client):
+    return client.post(
+        "/login",
+        data={"username": "admin", "password": "adminpass"},
+        follow_redirects=True,
+    )
+
+
+class TestChannelInfoBannerGuideMarkup:
+    def test_guide_contains_inline_and_fullscreen_banner_markup(self, client):
+        login(client)
+        resp = client.get("/guide")
+        assert resp.status_code == 200
+        html = resp.data.decode()
+        assert 'id="chanInfoBtn"' in html
+        assert 'id="channelInfoBanner"' in html
+        assert 'id="vcFsOverlayInfo"' in html
+        assert 'id="vcFsChannelInfoBanner"' in html
+
+    def test_guide_exposes_channel_info_banner_toggle_hook(self, client):
+        login(client)
+        resp = client.get("/guide")
+        assert resp.status_code == 200
+        html = resp.data.decode()
+        assert "window.showChannelInfoBanner =" in html
+        assert "window.toggleChannelInfoBanner = toggleBanner;" in html
+
+    def test_guide_includes_native_fullscreen_styles(self, client):
+        login(client)
+        resp = client.get("/guide")
+        assert resp.status_code == 200
+        html = resp.data.decode()
+        assert (
+            "#video:fullscreen,\n"
+            "    #video:-webkit-full-screen {\n"
+            "        width: 100vw !important;\n"
+            "        height: 100vh !important;\n"
+            "        object-fit: contain !important;\n"
+            "    }"
+        ) in html

--- a/tests/test_channel_number_entry.py
+++ b/tests/test_channel_number_entry.py
@@ -1,0 +1,281 @@
+"""Tests for channel number entry feature:
+- parse_m3u() correctly extracts tvg-chno from M3U EXTINF tags (including
+  decimal sub-channel numbers like "2.1", "16.5", "31.2")
+- guide template exposes data-chan-num attribute (smoke test via app client)
+"""
+import os
+import sys
+import json
+import subprocess
+from pathlib import Path
+import pytest
+from unittest.mock import patch, MagicMock
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+import app as app_module
+from app import app, init_db, init_tuners_db, parse_m3u
+
+
+# ─── Fixtures ────────────────────────────────────────────────────────────────
+
+@pytest.fixture(autouse=True)
+def isolated_db(tmp_path, monkeypatch):
+    """Each test gets its own empty SQLite database."""
+    users_db  = str(tmp_path / "users_test.db")
+    tuners_db = str(tmp_path / "tuners_test.db")
+    monkeypatch.setattr(app_module, "DATABASE",  users_db)
+    monkeypatch.setattr(app_module, "TUNER_DB",  tuners_db)
+    init_db()
+    init_tuners_db()
+    from app import add_user
+    add_user("testuser", "testpass")
+    yield
+
+
+@pytest.fixture()
+def client(isolated_db):
+    app.config["TESTING"] = True
+    app.config["WTF_CSRF_ENABLED"] = False
+    with app.test_client() as c:
+        yield c
+
+
+def login(client):
+    return client.post("/login", data={"username": "testuser", "password": "testpass"},
+                       follow_redirects=True)
+
+
+# ─── M3U parsing tests ────────────────────────────────────────────────────────
+
+M3U_WITH_CHNO = """\
+#EXTM3U
+#EXTINF:-1 tvg-id="ch1" tvg-chno="5" tvg-logo="" group-title="News",CNN
+http://example.com/cnn.m3u8
+#EXTINF:-1 tvg-id="ch2" tvg-chno="42" tvg-logo="" group-title="Sports",ESPN
+http://example.com/espn.m3u8
+#EXTINF:-1 tvg-id="ch3" tvg-logo="" group-title="Movies",HBO
+http://example.com/hbo.m3u8
+"""
+
+M3U_WITHOUT_CHNO = """\
+#EXTM3U
+#EXTINF:-1 tvg-id="ch1" tvg-logo="" group-title="News",BBC News
+http://example.com/bbc.m3u8
+#EXTINF:-1 tvg-id="ch2" tvg-logo="" group-title="Sports",Sky Sports
+http://example.com/sky.m3u8
+"""
+
+M3U_DECIMAL_CHNO = """\
+#EXTM3U
+#EXTINF:-1 tvg-id="sub1" tvg-chno="2.1" tvg-logo="" group-title="OTA",WFOO-HD
+http://example.com/wfoo-hd.m3u8
+#EXTINF:-1 tvg-id="sub2" tvg-chno="16.5" tvg-logo="" group-title="OTA",WBAR-SD
+http://example.com/wbar-sd.m3u8
+#EXTINF:-1 tvg-id="sub3" tvg-chno="31.2" tvg-logo="" group-title="OTA",WBAZ-DT2
+http://example.com/wbaz-dt2.m3u8
+"""
+
+
+def _mock_requests_get(m3u_text):
+    """Return a requests.get mock that serves the given M3U text."""
+    mock_resp = MagicMock()
+    mock_resp.raise_for_status = MagicMock()
+    mock_resp.text = m3u_text
+    mock_get = MagicMock(return_value=mock_resp)
+    return mock_get
+
+
+class TestParseM3uTvgChno:
+    """parse_m3u() should extract tvg-chno into the 'tvg_chno' field."""
+
+    def test_tvg_chno_extracted_when_present(self):
+        with patch("app.requests.get", _mock_requests_get(M3U_WITH_CHNO)):
+            channels = parse_m3u("http://fake.url/playlist.m3u")
+        assert len(channels) == 3
+        assert channels[0]["tvg_chno"] == "5"
+        assert channels[1]["tvg_chno"] == "42"
+
+    def test_tvg_chno_empty_when_absent(self):
+        with patch("app.requests.get", _mock_requests_get(M3U_WITH_CHNO)):
+            channels = parse_m3u("http://fake.url/playlist.m3u")
+        # Third channel has no tvg-chno attribute
+        assert channels[2]["tvg_chno"] == ""
+
+    def test_tvg_chno_defaults_to_empty_when_not_in_m3u(self):
+        with patch("app.requests.get", _mock_requests_get(M3U_WITHOUT_CHNO)):
+            channels = parse_m3u("http://fake.url/playlist.m3u")
+        for ch in channels:
+            assert "tvg_chno" in ch
+            assert ch["tvg_chno"] == ""
+
+    def test_other_channel_fields_still_parsed(self):
+        with patch("app.requests.get", _mock_requests_get(M3U_WITH_CHNO)):
+            channels = parse_m3u("http://fake.url/playlist.m3u")
+        assert channels[0]["name"] == "CNN"
+        assert channels[0]["tvg_id"] == "ch1"
+        assert channels[0]["url"] == "http://example.com/cnn.m3u8"
+        assert channels[1]["name"] == "ESPN"
+        assert channels[1]["tvg_chno"] == "42"
+
+    def test_tvg_chno_with_leading_trailing_spaces_is_stripped(self):
+        m3u = (
+            "#EXTM3U\n"
+            '#EXTINF:-1 tvg-id="ch1" tvg-chno=" 7 " tvg-logo="" group-title="News",Test\n'
+            "http://example.com/test.m3u8\n"
+        )
+        with patch("app.requests.get", _mock_requests_get(m3u)):
+            channels = parse_m3u("http://fake.url/playlist.m3u")
+        assert channels[0]["tvg_chno"] == "7"
+
+
+class TestParseM3uDecimalChno:
+    """parse_m3u() should preserve decimal sub-channel numbers verbatim."""
+
+    def test_decimal_chno_preserved(self):
+        with patch("app.requests.get", _mock_requests_get(M3U_DECIMAL_CHNO)):
+            channels = parse_m3u("http://fake.url/playlist.m3u")
+        assert len(channels) == 3
+        assert channels[0]["tvg_chno"] == "2.1"
+        assert channels[1]["tvg_chno"] == "16.5"
+        assert channels[2]["tvg_chno"] == "31.2"
+
+    def test_decimal_chno_channel_names_correct(self):
+        with patch("app.requests.get", _mock_requests_get(M3U_DECIMAL_CHNO)):
+            channels = parse_m3u("http://fake.url/playlist.m3u")
+        assert channels[0]["name"] == "WFOO-HD"
+        assert channels[1]["name"] == "WBAR-SD"
+        assert channels[2]["name"] == "WBAZ-DT2"
+
+    def test_mixed_integer_and_decimal_chno(self):
+        m3u = (
+            "#EXTM3U\n"
+            '#EXTINF:-1 tvg-id="a" tvg-chno="2" tvg-logo="" group-title="",Main\n'
+            "http://example.com/main.m3u8\n"
+            '#EXTINF:-1 tvg-id="b" tvg-chno="2.1" tvg-logo="" group-title="",Sub1\n'
+            "http://example.com/sub1.m3u8\n"
+            '#EXTINF:-1 tvg-id="c" tvg-chno="2.2" tvg-logo="" group-title="",Sub2\n'
+            "http://example.com/sub2.m3u8\n"
+        )
+        with patch("app.requests.get", _mock_requests_get(m3u)):
+            channels = parse_m3u("http://fake.url/playlist.m3u")
+        assert channels[0]["tvg_chno"] == "2"
+        assert channels[1]["tvg_chno"] == "2.1"
+        assert channels[2]["tvg_chno"] == "2.2"
+
+
+def _simulate_channel_number_entry(channels, keys):
+    js_path = Path(app_module.app.static_folder) / "js" / "channel-number-entry.js"
+    payload = json.dumps({"channels": channels, "keys": keys, "script_path": str(js_path)})
+    node_script = r"""
+const fs = require('fs');
+const vm = require('vm');
+const input = JSON.parse(process.argv[1]);
+const source = fs.readFileSync(input.script_path, 'utf8');
+
+let keydownHandler = null;
+const clickLog = [];
+
+function makeChan(ch) {
+  return {
+    dataset: {
+      chanNum: String(ch.num || ''),
+      isVirtual: ch.is_virtual ? 'true' : 'false'
+    },
+    closest: () => null,
+    focus: () => {},
+    click: () => { clickLog.push(ch.name); },
+    scrollIntoView: () => {}
+  };
+}
+
+const chanEls = input.channels.map(makeChan);
+
+const document = {
+  head: { appendChild: () => {} },
+  body: { appendChild: () => {} },
+  querySelectorAll: (sel) => sel === '.chan-name' ? chanEls : [],
+  addEventListener: (event, cb) => { if (event === 'keydown') keydownHandler = cb; },
+  createElement: () => ({
+    classList: { add: () => {}, remove: () => {} },
+    setAttribute: () => {},
+    appendChild: () => {},
+    textContent: '',
+    id: ''
+  })
+};
+
+const context = {
+  document,
+  window: {},
+  setTimeout: (fn, ms) => {
+    if (ms !== 1500) fn();
+    return 1;
+  },
+  clearTimeout: () => {}
+};
+
+vm.runInNewContext(source, context, { filename: 'channel-number-entry.js' });
+
+for (const key of input.keys) {
+  keydownHandler({
+    key,
+    target: { tagName: 'DIV' },
+    preventDefault: () => {},
+    stopImmediatePropagation: () => {}
+  });
+}
+
+process.stdout.write(JSON.stringify(clickLog));
+"""
+    proc = subprocess.run(
+        ["node", "-e", node_script, payload],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    return json.loads(proc.stdout)
+
+
+class TestChannelNumberEntryDuplicateResolution:
+    def test_virtual_channel_is_preferred_over_real_on_duplicate_number(self):
+        clicked = _simulate_channel_number_entry(
+            [
+                {"name": "Real Five", "num": "5", "is_virtual": False},
+                {"name": "Virtual Five", "num": "5", "is_virtual": True},
+            ],
+            ["5", "Enter"],
+        )
+        assert clicked == ["Virtual Five"]
+
+    def test_non_virtual_duplicate_keeps_first_match(self):
+        clicked = _simulate_channel_number_entry(
+            [
+                {"name": "Real Five A", "num": "5", "is_virtual": False},
+                {"name": "Real Five B", "num": "5", "is_virtual": False},
+            ],
+            ["5", "Enter"],
+        )
+        assert clicked == ["Real Five A"]
+
+
+class TestChannelNumberEntrySequentialAlias:
+    def test_first_real_channel_reachable_by_sequential_number_after_virtuals(self):
+        channels = [
+            {"name": f"Virtual {i}", "num": str(i), "is_virtual": True}
+            for i in range(1, 10)
+        ]
+        channels.append({"name": "Real 2.1", "num": "2.1", "is_virtual": False})
+
+        clicked = _simulate_channel_number_entry(channels, ["1", "0", "Enter"])
+        assert clicked == ["Real 2.1"]
+
+    def test_explicit_decimal_number_still_works_with_sequential_alias(self):
+        channels = [
+            {"name": f"Virtual {i}", "num": str(i), "is_virtual": True}
+            for i in range(1, 10)
+        ]
+        channels.append({"name": "Real 2.1", "num": "2.1", "is_virtual": False})
+
+        clicked = _simulate_channel_number_entry(channels, ["2", ".", "1", "Enter"])
+        assert clicked == ["Real 2.1"]

--- a/tests/test_guide_search_filter.py
+++ b/tests/test_guide_search_filter.py
@@ -1,0 +1,119 @@
+import os
+import sys
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+import app as app_module
+from app import app, init_db, init_tuners_db, add_user, parse_epg
+
+
+@pytest.fixture(autouse=True)
+def isolated_db(tmp_path, monkeypatch):
+    users_db = str(tmp_path / "users_test.db")
+    tuners_db = str(tmp_path / "tuners_test.db")
+    monkeypatch.setattr(app_module, "DATABASE", users_db)
+    monkeypatch.setattr(app_module, "TUNER_DB", tuners_db)
+    init_db()
+    init_tuners_db()
+    add_user("admin", "adminpass")
+    yield
+
+
+@pytest.fixture()
+def client(isolated_db):
+    app.config["TESTING"] = True
+    with app.test_client() as c:
+        yield c
+
+
+def login(client):
+    return client.post(
+        "/login",
+        data={"username": "admin", "password": "adminpass"},
+        follow_redirects=True,
+    )
+
+
+class _MockResponse:
+    def __init__(self, content: bytes):
+        self.content = content
+
+    def raise_for_status(self):
+        return None
+
+
+class TestGuideSearchFilter:
+    def test_guide_search_panel_is_hidden_by_default_and_has_toggle_hooks(self, client):
+        login(client)
+        resp = client.get("/guide")
+        assert resp.status_code == 200
+        assert b'id="guideSearchToggle"' in resp.data
+        assert b'id="mobileGuideSearchToggle"' in resp.data
+        assert b'id="guideSearchPanel"' in resp.data
+        assert b'id="guideSearchPanel" class="guide-filter-panel" role="search" hidden' in resp.data
+        assert b'id="guideSearchInput"' in resp.data
+        assert b'id="guideTypeFilter"' in resp.data
+        assert b"toggleGuideSearchPanel" in resp.data
+
+    def test_guide_search_toggle_renders_between_home_and_settings(self, client):
+        login(client)
+        resp = client.get("/guide")
+        html = resp.data.decode("utf-8")
+        home_pos = html.find(">HOME</a>")
+        search_pos = html.find('id="guideSearchToggle"')
+        settings_pos = html.find('id="settingsMenu"')
+        assert home_pos != -1
+        assert search_pos != -1
+        assert settings_pos != -1
+        assert home_pos < search_pos < settings_pos
+
+    def test_parse_epg_includes_category_and_color_metadata(self, monkeypatch):
+        xml = b"""<?xml version="1.0" encoding="UTF-8"?>
+<tv>
+  <channel id="ch1"><display-name>Channel One</display-name></channel>
+  <programme channel="ch1" start="20260101010000 +0000" stop="20260101020000 +0000">
+    <title>Movie Night</title>
+    <category>Movies</category>
+    <colour>Blue</colour>
+    <color>Gold</color>
+  </programme>
+</tv>
+"""
+
+        monkeypatch.setattr(app_module.requests, "get", lambda *_args, **_kwargs: _MockResponse(xml))
+        epg = parse_epg("http://example.test/guide.xml")
+        assert epg["ch1"][0]["categories"] == ["Movies"]
+        assert epg["ch1"][0]["colors"] == ["Blue", "Gold"]
+
+    def test_guide_program_blocks_render_category_and_color_data(self, client, monkeypatch):
+        now = datetime.now(timezone.utc)
+        monkeypatch.setattr(app_module, "cached_channels", [
+            {
+                "name": "Channel One",
+                "logo": "",
+                "url": "http://example.test/ch1.m3u8",
+                "tvg_id": "ch1",
+                "group": "Movies",
+                "tvg_chno": "101",
+            }
+        ])
+        monkeypatch.setattr(app_module, "cached_epg", {
+            "ch1": [{
+                "title": "Movie Night",
+                "desc": "Feature film",
+                "start": now - timedelta(minutes=10),
+                "stop": now + timedelta(minutes=50),
+                "icon": "",
+                "categories": ["Movies", "Drama"],
+                "colors": ["Blue"],
+            }]
+        })
+
+        login(client)
+        resp = client.get("/guide")
+        assert resp.status_code == 200
+        assert b'data-categories="Movies | Drama"' in resp.data
+        assert b'data-colors="Blue"' in resp.data

--- a/tests/test_last_channel_return.py
+++ b/tests/test_last_channel_return.py
@@ -1,0 +1,111 @@
+"""Tests for the "Last Channel Return" feature (v4.9.6).
+
+Verifies that:
+- guide.html exposes the `window.returnToLastChannel` global function.
+- guide.html declares the `lastChannelMeta` state variable.
+- guide.html updates `window.lastChannelMeta` inside playChannel().
+- channel-number-entry.js handles the `L` key to trigger last-channel return.
+"""
+import os
+import sys
+
+import pytest
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+import app as app_module
+from app import app, init_db, init_tuners_db, add_user
+
+
+# ─── Fixtures ────────────────────────────────────────────────────────────────
+
+@pytest.fixture(autouse=True)
+def isolated_db(tmp_path, monkeypatch):
+    users_db = str(tmp_path / "users_test.db")
+    tuners_db = str(tmp_path / "tuners_test.db")
+    monkeypatch.setattr(app_module, "DATABASE", users_db)
+    monkeypatch.setattr(app_module, "TUNER_DB", tuners_db)
+    init_db()
+    init_tuners_db()
+    add_user("admin", "adminpass")
+    yield
+
+
+@pytest.fixture()
+def client(isolated_db):
+    app.config["TESTING"] = True
+    with app.test_client() as c:
+        yield c
+
+
+def login(client):
+    return client.post(
+        "/login",
+        data={"username": "admin", "password": "adminpass"},
+        follow_redirects=True,
+    )
+
+
+# ─── Guide template tests ─────────────────────────────────────────────────────
+
+class TestLastChannelReturnGuide:
+    def test_guide_exposes_last_channel_meta_on_window(self, client):
+        login(client)
+        resp = client.get("/guide")
+        assert resp.status_code == 200
+        html = resp.data.decode()
+        assert "window.lastChannelMeta" in html
+
+    def test_guide_exposes_return_to_last_channel_function(self, client):
+        login(client)
+        resp = client.get("/guide")
+        assert resp.status_code == 200
+        html = resp.data.decode()
+        assert "window.returnToLastChannel" in html
+
+    def test_guide_updates_window_last_channel_meta(self, client):
+        login(client)
+        resp = client.get("/guide")
+        assert resp.status_code == 200
+        html = resp.data.decode()
+        assert "window.lastChannelMeta = Object.assign" in html
+
+    def test_guide_saves_previous_channel_before_switching(self, client):
+        """The playChannel function must save the prior channel before overwriting currentChannelMeta."""
+        login(client)
+        resp = client.get("/guide")
+        assert resp.status_code == 200
+        html = resp.data.decode()
+        # The guard condition — only save when switching to a different channel
+        assert "currentChannelId !== cid" in html
+
+
+# ─── channel-number-entry.js tests ───────────────────────────────────────────
+
+class TestLastChannelReturnKeyBinding:
+    def _read_js(self):
+        js_path = os.path.join(
+            os.path.dirname(os.path.dirname(os.path.abspath(__file__))),
+            "static", "js", "channel-number-entry.js",
+        )
+        with open(js_path, encoding="utf-8") as fh:
+            return fh.read()
+
+    def test_l_key_handler_present(self):
+        js = self._read_js()
+        assert "'l'" in js or '"l"' in js
+
+    def test_l_key_calls_return_to_last_channel(self):
+        js = self._read_js()
+        assert "returnToLastChannel" in js
+
+    def test_l_key_only_fires_when_buffer_empty(self):
+        """The L key handler must be guarded by `!buffer` to avoid conflicts with digit entry."""
+        js = self._read_js()
+        # Find the L key block and confirm the !buffer guard is present
+        assert "!buffer" in js
+
+    def test_l_key_checks_last_channel_meta_exists(self):
+        """The L key handler should only fire if window.lastChannelMeta is set."""
+        js = self._read_js()
+        assert "window.lastChannelMeta" in js

--- a/tests/test_user_prefs.py
+++ b/tests/test_user_prefs.py
@@ -213,6 +213,38 @@ class TestApiUserPrefsPost:
                     content_type="application/json")
         assert get_user_prefs("testuser")["auto_load_channel"] is None
 
+    def test_channel_numbers_enabled_can_be_toggled_via_api(self, client):
+        login(client)
+        resp = client.post(
+            "/api/user_prefs",
+            data=json.dumps({"channel_numbers_enabled": True}),
+            content_type="application/json",
+        )
+        assert resp.status_code == 200
+        prefs = get_user_prefs("testuser")
+        assert prefs["channel_numbers_enabled"] is True
+
+    def test_channel_numbers_enabled_invalid_value_coerces_false(self, client):
+        login(client)
+        save_user_prefs("testuser", {"channel_numbers_enabled": True})
+        resp = client.post(
+            "/api/user_prefs",
+            data=json.dumps({"channel_numbers_enabled": "yes"}),
+            content_type="application/json",
+        )
+        assert resp.status_code == 200
+        prefs = get_user_prefs("testuser")
+        assert prefs["channel_numbers_enabled"] is False
+
+
+class TestGuideChannelNumberToggleUi:
+    def test_guide_preferences_include_channel_number_toggle_controls(self, client):
+        login(client)
+        resp = client.get("/guide")
+        assert resp.status_code == 200
+        assert b'id="toggleChannelNumbers"' in resp.data
+        assert b'id="mobileToggleChannelNumbers"' in resp.data
+
 
 # ─── Admin: manage_users set_user_prefs action ───────────────────────────────
 
@@ -521,3 +553,74 @@ class TestManageUsersHiddenChannels:
         resp = client.get("/manage_users")
         assert resp.status_code == 200
         assert b"1 channel hidden" in resp.data
+
+
+# ─── Favorites feature ────────────────────────────────────────────────────────
+
+class TestFavoriteChannels:
+    """Tests for the lightweight favorites feature."""
+
+    def test_default_favorite_channels_is_empty_list(self):
+        prefs = get_user_prefs("newuser")
+        assert "favorite_channels" in prefs
+        assert prefs["favorite_channels"] == []
+
+    def test_save_and_retrieve_favorites(self):
+        save_user_prefs("testuser", {"favorite_channels": ["ch1", "ch2"]})
+        prefs = get_user_prefs("testuser")
+        assert prefs["favorite_channels"] == ["ch1", "ch2"]
+
+    def test_add_favorite_via_api(self, client):
+        login(client)
+        resp = client.post("/api/user_prefs",
+                           data=json.dumps({"favorite_channels": ["sports", "news"]}),
+                           content_type="application/json")
+        assert resp.status_code == 200
+        body = resp.get_json()
+        assert body["status"] == "ok"
+        assert "sports" in body["prefs"]["favorite_channels"]
+        assert "news" in body["prefs"]["favorite_channels"]
+
+    def test_clear_favorites_via_api(self, client):
+        login(client)
+        save_user_prefs("testuser", {"favorite_channels": ["ch1", "ch2"]})
+        resp = client.post("/api/user_prefs",
+                           data=json.dumps({"favorite_channels": []}),
+                           content_type="application/json")
+        assert resp.status_code == 200
+        assert get_user_prefs("testuser")["favorite_channels"] == []
+
+    def test_invalid_favorites_rejected(self, client):
+        """Non-list value for favorite_channels is coerced to empty list."""
+        login(client)
+        resp = client.post("/api/user_prefs",
+                           data=json.dumps({"favorite_channels": "not-a-list"}),
+                           content_type="application/json")
+        assert resp.status_code == 200
+        assert get_user_prefs("testuser")["favorite_channels"] == []
+
+    def test_partial_update_preserves_favorites(self, client):
+        login(client)
+        save_user_prefs("testuser", {
+            "auto_load_channel": {"id": "ch1", "name": "News"},
+            "favorite_channels": ["ch1", "ch2"],
+        })
+        # Update only hidden_channels — favorites must not be touched
+        client.post("/api/user_prefs",
+                    data=json.dumps({"hidden_channels": ["ch3"]}),
+                    content_type="application/json")
+        prefs = get_user_prefs("testuser")
+        assert prefs["favorite_channels"] == ["ch1", "ch2"]  # unchanged
+
+    def test_favorite_channels_in_default_prefs(self):
+        assert "favorite_channels" in _DEFAULT_PREFS
+        assert _DEFAULT_PREFS["favorite_channels"] == []
+
+    def test_api_get_includes_favorite_channels(self, client):
+        login(client)
+        save_user_prefs("testuser", {"favorite_channels": ["movie-ch"]})
+        resp = client.get("/api/user_prefs")
+        assert resp.status_code == 200
+        data = resp.get_json()
+        assert "favorite_channels" in data
+        assert "movie-ch" in data["favorite_channels"]

--- a/tests/test_user_prefs_channel_numbers.py
+++ b/tests/test_user_prefs_channel_numbers.py
@@ -1,0 +1,176 @@
+"""Focused tests for user-prefs channel number overlay behavior."""
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+import app as app_module
+
+
+def _simulate_user_prefs_channel_numbers(channels, body_classes=None, add_channel=None):
+    js_path = Path(app_module.app.static_folder) / "js" / "user-prefs.js"
+    payload = json.dumps({
+        "channels": channels,
+        "body_classes": body_classes or [],
+        "add_channel": add_channel,
+        "script_path": str(js_path),
+    })
+    node_script = r"""
+const fs = require('fs');
+const vm = require('vm');
+const input = JSON.parse(process.argv[1]);
+const source = fs.readFileSync(input.script_path, 'utf8');
+
+function makeClassList(initial = []) {
+  const s = new Set(initial);
+  return {
+    add: (...items) => items.forEach(i => s.add(i)),
+    remove: (...items) => items.forEach(i => s.delete(i)),
+    toggle: (item, force) => {
+      if (force === true) { s.add(item); return true; }
+      if (force === false) { s.delete(item); return false; }
+      if (s.has(item)) { s.delete(item); return false; }
+      s.add(item); return true;
+    },
+    contains: (item) => s.has(item)
+  };
+}
+
+function makeUserNumNode(text) {
+  return {
+    className: 'user-channel-number',
+    textContent: text,
+    remove: function () {
+      if (!this._parent) return;
+      const i = this._parent._children.indexOf(this);
+      if (i >= 0) this._parent._children.splice(i, 1);
+      this._parent = null;
+    }
+  };
+}
+
+function makeChannel(cid, hasBuiltIn) {
+  const el = {
+    dataset: { cid },
+    _children: [],
+    firstChild: null,
+    addEventListener: () => {},
+    closest: () => null,
+    querySelector: (sel) => {
+      if (sel === '.channel-number') return hasBuiltIn ? { className: 'channel-number' } : null;
+      if (sel === '.user-channel-number') return el._children.find(n => n.className === 'user-channel-number') || null;
+      return null;
+    },
+    insertBefore: (node) => {
+      node._parent = el;
+      el._children.unshift(node);
+      el.firstChild = el._children[0] || null;
+    }
+  };
+  return el;
+}
+
+const chanEls = input.channels.map(ch => makeChannel(ch.cid, !!ch.built_in));
+const rows = input.channels.map(ch => ({ dataset: { cid: ch.cid }, classList: makeClassList() }));
+const guideOuter = {};
+let domReadyCb = null;
+let mutationCb = null;
+
+const document = {
+  readyState: 'loading',
+  body: { classList: makeClassList(input.body_classes || []) },
+  querySelectorAll: (sel) => {
+    if (sel === '.guide-row[data-cid]') return rows;
+    if (sel === '.guide-row[data-cid] .chan-name') return chanEls;
+    if (sel === '.chan-name') return chanEls;
+    if (sel === '.chan-name .user-channel-number') {
+      return chanEls.flatMap(ch => ch._children.filter(n => n.className === 'user-channel-number'));
+    }
+    return [];
+  },
+  getElementById: (id) => (id === 'guideOuter' ? guideOuter : null),
+  addEventListener: (event, cb) => {
+    if (event === 'DOMContentLoaded') domReadyCb = cb;
+  },
+  createElement: (tag) => {
+    if (tag === 'span') return makeUserNumNode('');
+    return { className: '', textContent: '', remove: () => {} };
+  }
+};
+
+const windowObj = {
+  __initialUserPrefs: { channel_numbers_enabled: true },
+  addEventListener: () => {},
+  console,
+};
+
+function MutationObserver(cb) {
+  this.observe = () => { mutationCb = cb; };
+}
+
+const context = {
+  document,
+  window: windowObj,
+  MutationObserver,
+  fetch: async () => ({ ok: true, json: async () => ({ prefs: { channel_numbers_enabled: true } }) }),
+  alert: () => {},
+  CSS: { escape: (s) => s },
+  setTimeout: (fn) => { fn(); return 1; },
+  clearTimeout: () => {},
+  console,
+};
+
+vm.runInNewContext(source, context, { filename: 'user-prefs.js' });
+if (domReadyCb) domReadyCb();
+
+function labels() {
+  return chanEls.map(ch => {
+    const n = ch.querySelector('.user-channel-number');
+    return n ? n.textContent : '';
+  });
+}
+
+const out = { initial: labels() };
+
+if (input.add_channel) {
+  chanEls.push(makeChannel(input.add_channel.cid, !!input.add_channel.built_in));
+  rows.push({ dataset: { cid: input.add_channel.cid }, classList: makeClassList() });
+  if (mutationCb) mutationCb([{ type: 'childList', addedNodes: [1], removedNodes: [] }]);
+  out.afterMutation = labels();
+}
+
+process.stdout.write(JSON.stringify(out));
+"""
+    proc = subprocess.run(
+        ["node", "-e", node_script, payload],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    return json.loads(proc.stdout)
+
+
+def test_user_channel_numbers_follow_current_row_order():
+    result = _simulate_user_prefs_channel_numbers(
+        channels=[
+            {"cid": "virtual.news"},
+            {"cid": "real.1"},
+            {"cid": "real.2"},
+        ],
+        add_channel={"cid": "virtual.weather"},
+    )
+    assert result["initial"] == ["CH 1", "CH 2", "CH 3"]
+    assert result["afterMutation"] == ["CH 1", "CH 2", "CH 3", "CH 4"]
+
+
+def test_user_channel_numbers_not_injected_for_builtin_number_theme():
+    result = _simulate_user_prefs_channel_numbers(
+        channels=[
+            {"cid": "virtual.news"},
+            {"cid": "real.1"},
+        ],
+        body_classes=["tvguide1990"],
+    )
+    assert result["initial"] == ["", ""]


### PR DESCRIPTION
## v4.9.6 - 2026-06-11

### Added

* Added **Favorites (lightweight)** feature.

  * Users can right-click any channel name in the guide grid to **Add to Favorites** or **Remove from Favorites**.
  * Favorite channels are persisted server-side per user account through the existing user preferences system.
  * Favorited channels are marked with a star badge in the guide.
  * Added **Show Favorites Only** toggle to the **Guide Preferences** submenu on desktop and mobile.
  * Toggle label updates to **Show All Channels** when the favorites-only filter is active.

* Added **Channel Info Banner** to the guide player.

  * Banner appears when tuning a channel and displays channel logo, channel number, channel name, current program title, program time range, progress bar, remaining time, and description.
  * Added an info button to manually toggle the banner.
  * Added keyboard shortcut support using the `i` key when focus is not inside an input field.
  * Added Channel Info Banner support inside virtual-channel fullscreen overlay mode.

* Added **Guide Search / Filter** panel.

  * Added SEARCH link to the guide header on desktop and mobile.
  * Users can search by channel name, program title, program description, group/type, category, and color metadata.
  * Added type filter dropdown populated from channel groups, virtual-channel markers, and XMLTV program categories.
  * Search/filter behavior updates visible guide rows and recomputes auto-scroll loops.

* Added **Channel Number Entry**.

  * Added `static/js/channel-number-entry.js`.
  * Users can type numeric channel numbers to jump directly to a channel.
  * Supports delayed auto-navigation after number entry.
  * Supports immediate confirmation with Enter.
  * Supports canceling entry with Escape or GoBack.
  * Supports decimal/sub-channel numbers such as `2.1`, `16.5`, and `31.2`.
  * Displays a retro-style channel-number HUD while typing.
  * Uses `tvg-chno` from M3U playlists when available, with row-index fallback when missing.

* Added **Last Channel Return**.

  * Stores the previously watched channel before switching to a new channel.
  * Added `window.returnToLastChannel()` helper.
  * Added `L` key shortcut support through channel-number entry handling.

* Added support for parsing `tvg-chno` values from M3U playlists.

  * Parsed channel numbers are stored on channel metadata as `tvg_chno`.
  * Guide rows now expose channel numbers through `data-chan-num`.
  * `/api/channels` now returns parsed `tvg-chno` values as the channel number when available.

* Added optional user-controlled channel-number display.

  * Added `channel_numbers_enabled` to default user preferences.
  * Added **Show Channel Numbers / Hide Channel Numbers** toggle to Guide Preferences on desktop and mobile.
  * User-injected channel numbers are hidden automatically for themes that already include built-in channel numbers, including `tvguide1990` and `classic-cable`.

* Added XMLTV metadata parsing for guide filtering.

  * Program categories are now parsed from XMLTV `<category>` entries.
  * Program color metadata is now parsed from XMLTV `<colour>` and `<color>` entries.
  * Guide program blocks now expose category and color metadata through `data-categories` and `data-colors`.

### Changed

* Improved guide player fullscreen behavior.

  * Native video fullscreen now uses `object-fit: contain` so video letterboxes instead of cropping.
  * Fullscreen control labeling was generalized from virtual-channel-only wording to broader fullscreen wording.

* Improved guide preference handling.

  * User preferences now include `favorite_channels` and `channel_numbers_enabled`.
  * API preference updates sanitize `favorite_channels` as a list of non-empty strings.
  * API preference updates coerce invalid `channel_numbers_enabled` values to `false`.

* Expanded the right-click channel context menu.

  * Added favorite and unfavorite actions.
  * Preserved existing play, auto-load, hide, and unhide actions.

### Fixed

* Fixed channel info display behavior for virtual channel fullscreen overlays.

  * Info banner and info button now appear correctly in fullscreen overlay mode.
  * Info banner controls fade consistently with fullscreen overlay controls.

* Fixed native video fullscreen cropping.

  * Browser fullscreen entered from the video control bar now preserves full video framing instead of cropping to fill.

* Fixed guide search/filter layout integration.

  * Opening or closing the search panel now refreshes the fixed time bar and now-line positioning.

### Tests

* Added `tests/test_channel_info_banner.py`.
* Added `tests/test_channel_number_entry.py`.
* Added `tests/test_guide_search_filter.py`.
* Added `tests/test_last_channel_return.py`.
* Added `tests/test_user_prefs_channel_numbers.py`.
* Expanded `tests/test_user_prefs.py` coverage for:

  * favorite channel defaults
  * saving and retrieving favorites
  * API favorite-channel updates
  * invalid favorite-channel sanitization
  * preserving favorites during partial preference updates
  * channel-number preference toggling
  * invalid channel-number preference sanitization
  * guide preference controls for channel-number display