### PR TITLE
v4.9.8 Merge into main

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ This project follows [Semantic Versioning](https://semver.org/).
 
 ---
 
-## v4.9.8 - 2026-07-03
+## v4.9.8 - 2026-07-10
 
 ### Added
 - (empty)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,13 +9,94 @@ This project follows [Semantic Versioning](https://semver.org/).
 ## v4.9.8 - 2026-07-10
 
 ### Added
-- (empty)
+
+* Added **EPG disk caching**.
+
+  * Added persistent on-disk EPG JSON cache under `DATA_DIR/epg_cache`.
+  * Added `EPG_CACHE_DIR` and `EPG_DISK_CACHE_TTL`.
+  * EPG cache defaults to a 24-hour TTL.
+  * Added safe cache filename generation for tuner names.
+  * Added EPG serialization/deserialization helpers for storing guide data with datetime values.
+  * Added stale-cache fallback when XMLTV loading returns no guide data.
+  * Added EPG caching support for both standard tuners and combined tuners.
+  * Added duplicate channel filtering by `tvg_id` when loading tuner data.
+
+* Added **per-user assigned tuner handling**.
+
+  * Added helper logic to determine the effective tuner for the current user.
+  * Guide, API channel list, Channel Health, Current Program, and What’s On Now now use the current user’s effective tuner instead of always using the global active tuner.
+  * Assigned tuners fall back to the current global tuner if the assigned tuner no longer exists.
+
+* Added **manual JSON cache refresh for selected tuners**.
+
+  * Added `/api/auto_refresh/trigger` endpoint.
+  * Admins can now force-refresh the selected tuner’s guide/JSON cache.
+  * Refreshing a non-active tuner updates that tuner’s cache without replacing the active in-memory guide.
+  * Updated the Change Tuner page button from **Run Sync Now** to **Refresh JSON Cache**.
+  * The refresh action now sends the selected tuner name and reports which tuner was refreshed.
+
+* Added shared pytest cache isolation.
+
+  * Added `tests/conftest.py` to isolate EPG cache files during tests.
+  * Added tests for EPG cache path handling, serialization, disk save/load, stale fallback, corrupt cache handling, and cache-aware tuner loading.
+  * Added tests for manual tuner cache refresh behavior.
 
 ### Changed
-- (empty)
 
-### Fixed
-- (empty)
+* Improved guide refresh behavior.
+
+  * Scheduled guide refresh now defers while video is actively playing, not only while fullscreen is active.
+  * Added handling for embedded playback, fullscreen playback, and Picture-in-Picture.
+  * Deferred refresh now runs after playback stops.
+  * Added debounce logic to avoid reloads during brief buffering pauses or channel switches.
+
+* Improved dynamic guide row preference handling.
+
+  * Hidden, favorite, and auto-load channel row states are now reapplied when guide rows are dynamically added or removed.
+  * Channel context-menu bindings are now reapplied for newly added channel rows.
+  * MutationObserver now watches guide row subtree changes instead of only top-level child changes.
+  * Hidden-channel visibility state is now preserved when showing hidden channels.
+
+* Improved guide search.
+
+  * Guide search/filter now indexes channel numbers in addition to channel names, groups, types, programs, and metadata.
+
+* Improved admin access enforcement.
+
+  * Weather background override API is now admin-only.
+  * Traffic demo city update, enable all, disable all, and random-pick actions are now admin-only.
+  * Added helper logic for checking admin user status.
+
+* Improved user-management behavior.
+
+  * Added tests confirming non-admin users cannot access Manage Users.
+  * Added tests confirming Android TV-style user agents are redirected away from Manage Users.
+  * Added test coverage for assigning tuners to users.
+
+* Updated ignored runtime/cache paths.
+
+  * Added runtime/cache directories to `.gitignore`, including:
+    * `runtime/`
+    * `config/runtime/`
+    * `config/cache/`
+    * `config/weather/`
+    * `config/epg_cache/`
+
+* Updated roadmap status.
+
+  * Marked **EPG caching** complete for v4.9.8.
+
+### Tests
+
+* Added `tests/test_epg_cache.py`.
+* Added `tests/test_tuner_cache_refresh.py`.
+* Added `tests/conftest.py`.
+* Updated tests for:
+  * Guide search/filter channel-number indexing.
+  * Traffic demo admin-only actions.
+  * Weather background override admin-only access.
+  * User preferences and assigned tuner behavior.
+  * Dynamic user preference reapplication after guide row mutations.
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -86,6 +86,14 @@ This project follows [Semantic Versioning](https://semver.org/).
 
   * Marked **EPG caching** complete for v4.9.8.
 
+* Removed **Mini Guide overlay** from the video player.
+
+  * Removed the semi-transparent channel list overlay that previously slid in over the video player.
+  * Removed the **☰ Mini Guide** player button.
+  * Removed the `G` keyboard shortcut that toggled the overlay.
+  * Removed overlay-only functions from `static/js/mini-guide.js` (`openMiniGuide`, `closeMiniGuide`, `toggleMiniGuide`, auto-dismiss timer, keyboard navigation).
+  * The **Mini Guide Layout** option (compact full-page list view) is unaffected and remains available.
+
 ### Tests
 
 * Added `tests/test_epg_cache.py`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,19 @@ This project follows [Semantic Versioning](https://semver.org/).
 
 ---
 
+## v4.9.8 - 2026-07-03
+
+### Added
+- (empty)
+
+### Changed
+- (empty)
+
+### Fixed
+- (empty)
+
+---
+
 ## v4.9.7 - 2026-07-03
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,19 @@ This project follows [Semantic Versioning](https://semver.org/).
   * Updated the Change Tuner page button from **Run Sync Now** to **Refresh JSON Cache**.
   * The refresh action now sends the selected tuner name and reports which tuner was refreshed.
 
+* Added **mobile Program Info folding**.
+
+  * Added a mobile-only **Hide Info / Program Info** toggle for the guide summary panel.
+  * The summary panel can collapse to free vertical space for the video and guide grid on small screens.
+  * Added one-minute auto-collapse while video is playing on mobile.
+  * The summary panel re-expands on channel changes.
+  * Added `static/js/mobile-summary-fold.js`.
+
+* Added **RetroStation MC theme**.
+
+  * Added `retrostation-mc` theme styling.
+  * Added RetroStation MC to the desktop and mobile theme menus.
+
 * Added shared pytest cache isolation.
 
   * Added `tests/conftest.py` to isolate EPG cache files during tests.
@@ -42,6 +55,18 @@ This project follows [Semantic Versioning](https://semver.org/).
   * Added tests for manual tuner cache refresh behavior.
 
 ### Changed
+
+* Updated release metadata to `v4.9.8` with release date `2026-07-10`.
+* Updated README version badge to `v4.9.8`.
+* Updated Linux, Raspberry Pi, Windows batch, and Windows PowerShell installer version metadata to `4.9.8`.
+
+* Improved **Linux installer and uninstaller behavior**.
+
+  * Renamed the Linux systemd service from `iptv-server` to `retroiptvguide`.
+  * Added legacy `iptv-server` service cleanup when the legacy unit is confirmed to belong to RetroIPTVGuide.
+  * Added safeguards so uninstall does not remove the shared `iptv` user/home directory when RetroStation MC or another service using that user is detected.
+  * Added RetroStation MC detection by service name, foreign `User=iptv` systemd units, and known install directories.
+  * Updated install/update flow to rewrite the current systemd service and clean owned legacy service files.
 
 * Improved guide refresh behavior.
 
@@ -61,11 +86,26 @@ This project follows [Semantic Versioning](https://semver.org/).
 
   * Guide search/filter now indexes channel numbers in addition to channel names, groups, types, programs, and metadata.
 
+* Improved mobile and responsive layout behavior.
+
+  * Added `#pageContent` as the internal scroll container for non-guide pages.
+  * Kept `#appZoomRoot` overflow hidden to avoid sticky-header issues, including iOS Safari behavior.
+  * Updated display-size handling so the default 1.0x zoom still applies the required root layout styles.
+  * Updated mobile video height calculations to account for whether the summary panel is expanded or collapsed.
+  * Removed the separate `mobile-scroll-fix.css` include from the base template.
+
 * Improved admin access enforcement.
 
   * Weather background override API is now admin-only.
   * Traffic demo city update, enable all, disable all, and random-pick actions are now admin-only.
   * Added helper logic for checking admin user status.
+
+* Improved diagnostics and stream-detection hardening.
+
+  * Stream detection now catches unexpected probe failures and returns a controlled JSON error instead of allowing an unhandled exception.
+  * Stream detection removes raw byte data from failed fetch responses.
+  * DNS failure messages are now less verbose to users.
+  * Service probe logging now strips query strings, fragments, and embedded credentials before writing URLs to logs.
 
 * Improved user-management behavior.
 
@@ -84,7 +124,11 @@ This project follows [Semantic Versioning](https://semver.org/).
 
 * Updated roadmap status.
 
-  * Marked **EPG caching** complete for v4.9.8.
+  * Marked **Browse mode** complete.
+  * Marked **What’s On Now** complete.
+  * Marked **EPG caching** complete.
+
+### Removed
 
 * Removed **Mini Guide overlay** from the video player.
 
@@ -92,17 +136,22 @@ This project follows [Semantic Versioning](https://semver.org/).
   * Removed the **☰ Mini Guide** player button.
   * Removed the `G` keyboard shortcut that toggled the overlay.
   * Removed overlay-only functions from `static/js/mini-guide.js` (`openMiniGuide`, `closeMiniGuide`, `toggleMiniGuide`, auto-dismiss timer, keyboard navigation).
-  * The **Mini Guide Layout** option (compact full-page list view) is unaffected and remains available.
+  * The **Mini Guide Layout** option, meaning the compact full-page list view, remains available.
 
 ### Tests
 
-* Added `tests/test_epg_cache.py`.
-* Added `tests/test_tuner_cache_refresh.py`.
 * Added `tests/conftest.py`.
+* Added `tests/test_epg_cache.py`.
+* Added `tests/test_install_scripts.py`.
+* Added `tests/test_tuner_cache_refresh.py`.
 * Updated tests for:
+  * Admin diagnostics stream-detection failure handling.
   * Guide search/filter channel-number indexing.
+  * Linux/Raspberry Pi installer shared-user protections.
+  * Mini Guide layout behavior after overlay removal.
   * Traffic demo admin-only actions.
   * Weather background override admin-only access.
+  * What’s On Now assigned-tuner behavior.
   * User preferences and assigned tuner behavior.
   * Dynamic user preference reapplication after guide row mutations.
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 <p align="center">
   <a href="https://github.com/thehack904/RetroIPTVGuide">
-    <img src="https://img.shields.io/badge/version-v4.9.7-blue?style=for-the-badge" alt="Version">
+    <img src="https://img.shields.io/badge/version-v4.9.8-blue?style=for-the-badge" alt="Version">
   </a>
   <a href="https://github.com/thehack904/RetroIPTVGuide/pkgs/container/retroiptvguide">
     <img src="https://img.shields.io/badge/GHCR-ghcr.io/thehack904/retroiptvguide-green?style=for-the-badge&logo=docker" alt="GHCR">

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -4,7 +4,7 @@ This document tracks **planned upgrades** and ideas for improving the IPTV Flask
 These are **not yet implemented**, partially implemented, or completed in previous releases.
 
 ---
-# Current Version: **v4.9.8 (2026-07-03)**
+# Current Version: **v4.9.8 (2026-07-10)**
 
 ---
 
@@ -51,7 +51,7 @@ These are **not yet implemented**, partially implemented, or completed in previo
 - [x] Mini Guide overlay *(v4.9.7)*  
 - [x] Missing EPG fallback *(v3.0.1)*  
 - [x] Reminders/notifications  *(v4.9.7)*
-- [ ] EPG caching  
+- [x] EPG caching  *(v4.9.8)*
 
 ---
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -4,7 +4,7 @@ This document tracks **planned upgrades** and ideas for improving the IPTV Flask
 These are **not yet implemented**, partially implemented, or completed in previous releases.
 
 ---
-# Current Version: **v4.9.7 (2026-07-03)**
+# Current Version: **v4.9.8 (2026-07-03)**
 
 ---
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -45,8 +45,9 @@ These are **not yet implemented**, partially implemented, or completed in previo
 - [x] Channel Info Banner *(v4.9.6)*  
 - [x] Channel number entry *(v4.9.6)*  
 - [x] Last channel return *(v4.9.6)*  
-- [ ] Browse mode  
-- [ ] "What's On Now" view  
+- [x] Browse mode *(v4.9.8)*
+- [x] "What's On Now" view *(v4.9.7)*
+- [x] EPG caching *(v4.9.8)*
 - [x] Channel health indicators (lightweight only) *(v4.9.7)*
 - [x] Mini Guide overlay *(v4.9.7)*  
 - [x] Missing EPG fallback *(v3.0.1)*  
@@ -81,7 +82,6 @@ These are **not yet implemented**, partially implemented, or completed in previo
 ### 6. Cross-Platform
 - [x] Linux / Windows / Raspberry Pi installers *(v4.0.0)*  
 - [x] Windows parity *(v4.1.0)*  
-- [ ] TrueNAS SCALE App Catalog certification  
 
 ---
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -18,10 +18,11 @@ These are **not yet implemented**, partially implemented, or completed in previo
 - [x] Validate tuner URLs *(v2.0.0 → improved v4.9.1–v4.9.2)*
 - [x] Duplicate tuner name prevention *(v4.6.0)*  
 - [x] Optional auto-refresh of tuner lineup *(v4.3.0)*  
-- [x] Per-user tuner assignment and default preferences *(v4.7.0)*  
+- [x] Per-user tuner assignment and default preferences *(v4.7.0 → enforced across guide APIs in v4.9.8)*  
 - [x] Combined tuner builder *(v4.7.0)*  
 - [x] Reworked Tuner Management UI *(v4.8.0)*  
 - [x] Virtual Channels split from Tuner Management *(v4.8.0)*  
+- [x] Manual selected-tuner JSON cache refresh *(v4.9.8)*
 
 ---
 
@@ -31,8 +32,9 @@ These are **not yet implemented**, partially implemented, or completed in previo
 - [x] System health checks *(v2.3.1)*  
 - [x] Admin log management *(v2.3.1)*  
 - [x] Post-install verification *(v3.1.0)*  
-- [x] Unified guide refresh scheduler *(v4.2.0)*  
-- [x] Sanitized diagnostics and error responses *(v4.9.1–v4.9.2)*  
+- [x] Unified guide refresh scheduler *(v4.2.0 → playback-aware deferral in v4.9.8)*  
+- [x] Sanitized diagnostics and error responses *(v4.9.1–v4.9.2 → improved v4.9.8)*  
+- [x] Channel health indicators (lightweight only) *(v4.9.7)*
 
 ---
 
@@ -41,28 +43,26 @@ These are **not yet implemented**, partially implemented, or completed in previo
 - [x] Responsive layout *(v4.2.0)*  
 - [x] Fullscreen improvements for virtual channels *(v4.9.3)*  
 - [x] Channel Mix dynamic fullscreen switching *(v4.9.3)*  
-- [x] Search/filter box *(v4.9.6)* 
+- [x] Search/filter box *(v4.9.6 → channel-number search added v4.9.8)* 
 - [x] Favorites (lightweight) *(v4.9.6)*  
 - [x] Channel Info Banner *(v4.9.6)*  
 - [x] Channel number entry *(v4.9.6)*  
 - [x] Last channel return *(v4.9.6)*  
 - [x] Browse mode *(v4.9.8)*
-- [x] "What's On Now" view *(v4.9.7)*
+- [x] "What's On Now" view *(v4.9.7 → assigned-tuner aware in v4.9.8)*
 - [x] EPG caching *(v4.9.8)*
-- [x] Channel health indicators (lightweight only) *(v4.9.7)*
-- [x] Mini Guide overlay *(v4.9.7)*  
-- [x] Missing EPG fallback *(v3.0.1)*  
-- [x] Reminders/notifications  *(v4.9.7)*
-- [x] EPG caching  *(v4.9.8)*
+- [x] Missing EPG fallback *(v3.0.1 → stale disk-cache fallback in v4.9.8)*  
+- [x] Reminders/notifications *(v4.9.7)*
+- [x] Mini Guide layout *(v4.9.7; video-player overlay removed v4.9.8)*
 
 ---
 
 ### 4. User Management
 - [x] User management UI *(v4.0.0)*  
-- [x] Basic admin-only access model *(initial v1.x; expanded through v2.0.0, v4.0.0, v4.9.2, and v4.9.3)* 
+- [x] Basic admin-only access model *(initial v1.x; expanded through v2.0.0, v4.0.0, v4.9.2, v4.9.3, and v4.9.8)* 
 - [x] Last login tracking *(v4.5.0)*  
 - [x] Auto-Load Channel *(v4.7.0)*  
-- [x] Assigned Tuner per User *(v4.7.0)*  
+- [x] Assigned Tuner per User *(v4.7.0 → guide/API enforcement improved v4.9.8)*  
 - [x] User role/channel restrictions *(v4.7.0 / v4.9.5)*
 
 ---
@@ -75,14 +75,17 @@ These are **not yet implemented**, partially implemented, or completed in previo
 - [x] Modular UI architecture *(v4.1.0)*  
 - [x] Mobile responsiveness *(v4.2.0)*  
 - [x] Theme auto-detect *(v4.5.0)*  
-- [x] Display size settings *(v4.6.0)*  
+- [x] Display size settings *(v4.6.0 → sticky/header scroll fix v4.9.8)*  
 - [x] Virtual channel fullscreen enhancements *(v4.8.0–v4.9.3)*  
+- [x] Mobile Program Info folding *(v4.9.8)*
+- [x] RetroStation MC theme *(v4.9.8)*
 
 ---
 
 ### 6. Cross-Platform
-- [x] Linux / Windows / Raspberry Pi installers *(v4.0.0)*  
+- [x] Linux / Windows / Raspberry Pi installers *(v4.0.0 → v4.9.8 metadata updates)*  
 - [x] Windows parity *(v4.1.0)*  
+- [x] Shared `iptv` user uninstall protection for RetroStation MC coexistence *(v4.9.8)* 
 
 ---
 
@@ -114,21 +117,25 @@ These are **not yet implemented**, partially implemented, or completed in previo
 ## ⚙️ Technical Improvements
 - [x] Docker containerization  
 - [x] DB schema migration guards *(v4.7.1)*  
-- [x] Security hardening *(v4.9.1–v4.9.2)*  
+- [x] Security hardening *(v4.9.1–v4.9.2 → admin API hardening and sanitized diagnostics in v4.9.8)*  
 - [x] Database-backed activity logging *(v4.9.3)*  
+- [x] EPG disk cache with safe tuner-name path handling *(v4.9.8)*
+- [x] Stale EPG disk-cache fallback when XMLTV reload returns empty data *(v4.9.8)*
 
 ---
 
 ## 🍓 Installer Enhancements
 - [x] Unified installer architecture  
 - [x] Windows parity  
-- [x] **Deprecate Windows installer in v5.0** — Docker is the recommended deployment method going forward *(notice added v4.9.4; effective v5.0)*   
+- [x] Linux service rename to `retroiptvguide` with owned legacy-service cleanup *(v4.9.8)*
+- [x] Preserve shared `iptv` user/home when RetroStation MC or another `iptv` service is detected *(v4.9.8)*
+- [ ] **Deprecate Windows installer in v5.0** — Docker is the recommended deployment method going forward *(notice added v4.9.4; pending v5.0)*
 
 ---
 
 ## User Submitted Enhancements
 - [x] Resize Pop Out Video *(v4.6.0)*
 - [x] Resize video *(v4.6.0)*
-- [x] Auto load Channel from Guide  *(v4.8.0)*
+- [x] Auto load Channel from Guide *(v4.8.0)*
 - [x] Adjustable scrolling speed *(v4.6.0)*
 - [x] Unraid Template

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -4,6 +4,7 @@ This document tracks **planned upgrades** and ideas for improving the IPTV Flask
 These are **not yet implemented**, partially implemented, or completed in previous releases.
 
 ---
+
 # Current Version: **v4.9.8 (2026-07-10)**
 
 ---
@@ -121,7 +122,7 @@ These are **not yet implemented**, partially implemented, or completed in previo
 ## 🍓 Installer Enhancements
 - [x] Unified installer architecture  
 - [x] Windows parity  
-- [ ] **Deprecate Windows installer in v5.0** — Docker is the recommended deployment method going forward  
+- [x] **Deprecate Windows installer in v5.0** — Docker is the recommended deployment method going forward *(notice added v4.9.4; effective v5.0)*   
 
 ---
 

--- a/app.py
+++ b/app.py
@@ -1,5 +1,5 @@
 # app.py — merged version (features from both sources)
-APP_VERSION = "v4.9.7"
+APP_VERSION = "v4.9.8-dev"
 APP_RELEASE_DATE = "2026-07-03"
 
 from flask import Flask, render_template, request, redirect, url_for, flash, session, jsonify, abort, make_response

--- a/app.py
+++ b/app.py
@@ -1,8 +1,8 @@
 # app.py — merged version (features from both sources)
-APP_VERSION = "v4.9.8-dev"
-APP_RELEASE_DATE = "2026-07-03"
+APP_VERSION = "v4.9.8"
+APP_RELEASE_DATE = "2026-07-10"
 
-from flask import Flask, render_template, request, redirect, url_for, flash, session, jsonify, abort, make_response
+from flask import Flask, render_template, request, redirect, url_for, flash, session, jsonify, abort, make_response, g
 from flask_login import LoginManager, UserMixin, login_user, login_required, logout_user, current_user
 from werkzeug.security import generate_password_hash, check_password_hash
 from werkzeug.utils import secure_filename
@@ -102,6 +102,8 @@ app.config['REMEMBER_COOKIE_DURATION'] = timedelta(days=30)
 DATABASE = os.path.join(DATA_DIR, 'users.db')
 TUNER_DB = os.path.join(DATA_DIR, 'tuners.db')
 ROADS_CACHE_DIR = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'data', 'roads_cache')
+EPG_CACHE_DIR = os.path.join(DATA_DIR, 'epg_cache')
+EPG_DISK_CACHE_TTL = 86400  # 24 hours — default on-disk TTL for EPG data
 ROADS_BUNDLED_DIR = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'static', 'data', 'roads')
 AUDIO_UPLOAD_DIR = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'static', 'audio')
 _ALLOWED_AUDIO_EXTENSIONS = {'mp3', 'ogg', 'wav', 'aac', 'm4a', 'flac'}
@@ -230,6 +232,12 @@ def _safe_next_url(raw: str) -> str:
     if not parsed.scheme and not parsed.netloc:
         return raw
     return ''
+
+
+def _is_admin_user(user=None) -> bool:
+    """Return True when the given (or current) user is the admin account."""
+    u = user if user is not None else current_user
+    return bool(getattr(u, 'is_authenticated', False) and getattr(u, 'username', None) == 'admin')
 
 
 # ------------------- User Model -------------------
@@ -575,8 +583,12 @@ def add_combined_tuner(name, sources):
         conn.commit()
 
 
-def load_tuner_data(tuner_name):
+def load_tuner_data(tuner_name, force_refresh=False):
     """Load channels and EPG for a tuner, supporting combined tuners.
+
+    EPG data is served from disk cache when available and fresh, avoiding a
+    costly XMLTV re-fetch on every app restart.  Pass ``force_refresh=True``
+    to bypass the cache and always fetch from the network.
 
     Returns:
         (channels, epg) — lists/dicts as returned by parse_m3u / parse_epg.
@@ -586,7 +598,34 @@ def load_tuner_data(tuner_name):
     if not tuner:
         return [], {}
 
+    def _dedupe_channels(channels):
+        """Keep first channel per tvg_id to avoid duplicate guide rows."""
+        seen = set()
+        unique = []
+        for ch in channels:
+            tvg_id = (ch.get("tvg_id") or "").strip()
+            if not tvg_id:
+                unique.append(ch)
+                continue
+            if tvg_id in seen:
+                continue
+            seen.add(tvg_id)
+            unique.append(ch)
+        return unique
+
     if tuner.get("tuner_type") == "combined":
+        # --- Combined tuner: try cache first ---
+        if not force_refresh:
+            cached = _load_epg_from_disk(tuner_name)
+            if cached is not None:
+                merged_channels = []
+                for source_name in tuner.get("sources", []):
+                    source = tuners.get(source_name)
+                    if not source:
+                        continue
+                    merged_channels.extend(parse_m3u(source["m3u"]) if source.get("m3u") else [])
+                return _dedupe_channels(merged_channels), cached
+
         merged_channels = []
         merged_epg = {}
         for source_name in tuner.get("sources", []):
@@ -597,10 +636,43 @@ def load_tuner_data(tuner_name):
             src_epg = parse_epg(source["xml"]) if source.get("xml") else {}
             merged_channels.extend(src_channels)
             merged_epg.update(src_epg)
-        return merged_channels, merged_epg
+
+        if merged_epg:
+            _save_epg_to_disk(tuner_name, merged_epg)
+        elif tuner.get("sources"):
+            # Network returned nothing — use stale cache as fallback if available
+            stale = _load_epg_from_disk(tuner_name, max_age=None)
+            if stale:
+                logging.info(
+                    "load_tuner_data: combined EPG fetch returned empty for tuner %r, "
+                    "using stale disk cache",
+                    tuner_name,
+                )
+                return _dedupe_channels(merged_channels), stale
+        return _dedupe_channels(merged_channels), merged_epg
     else:
         channels = parse_m3u(tuner["m3u"]) if tuner.get("m3u") else []
+        channels = _dedupe_channels(channels)
+
+        # --- Standard tuner: try cache first ---
+        if not force_refresh:
+            cached = _load_epg_from_disk(tuner_name)
+            if cached is not None:
+                return channels, cached
+
         epg = parse_epg(tuner["xml"]) if tuner.get("xml") else {}
+        if epg:
+            _save_epg_to_disk(tuner_name, epg)
+        elif tuner.get("xml"):
+            # Network returned nothing — use stale cache as fallback if available
+            stale = _load_epg_from_disk(tuner_name, max_age=None)
+            if stale:
+                logging.info(
+                    "load_tuner_data: EPG fetch returned empty for tuner %r, "
+                    "using stale disk cache",
+                    tuner_name,
+                )
+                return channels, stale
         return channels, epg
 @app.template_filter('format_datetime')
 def format_datetime_filter(iso_string):
@@ -685,8 +757,58 @@ def save_user_prefs(username, prefs):
         save_user_prefs(username, prefs)
 
 
+def get_assigned_tuner(username):
+    """Return the explicitly assigned tuner name for *username*, or None."""
+    try:
+        with sqlite3.connect(DATABASE, timeout=10) as conn:
+            c = conn.cursor()
+            c.execute("SELECT assigned_tuner FROM users WHERE username=?", (username,))
+            row = c.fetchone()
+        return (row[0] if row and row[0] else None)
+    except sqlite3.Error:
+        logging.exception("get_assigned_tuner failed for %r", username)
+        return None
+
+
+def get_effective_tuner_for_user(username):
+    """Return the tuner that should be used for *username* right now."""
+    current_tuner = get_current_tuner()
+    assigned = get_assigned_tuner(username)
+    if not assigned:
+        return current_tuner
+    tuners = get_tuners()
+    return assigned if assigned in tuners else current_tuner
+
+
+def get_request_tuner_data():
+    """Return (tuner_name, channels, epg) scoped to the current request/user."""
+    current_tuner = get_current_tuner()
+    tuner_name = current_tuner
+    if getattr(current_user, "is_authenticated", False):
+        tuner_name = get_effective_tuner_for_user(current_user.username)
+
+    if tuner_name == current_tuner:
+        return tuner_name, cached_channels, cached_epg
+
+    cache = g.setdefault("_tuner_data_cache", {})
+    if tuner_name in cache:
+        return tuner_name, cache[tuner_name][0], cache[tuner_name][1]
+
+    channels, epg = load_tuner_data(tuner_name)
+    epg = apply_epg_fallback(channels, epg)
+    cache[tuner_name] = (channels, epg)
+    return tuner_name, channels, epg
+
+
 cached_channels = []
 cached_epg = {}
+
+
+def _set_cached_tuner_data(channels, epg):
+    """Replace the in-memory guide cache with the provided channels and EPG."""
+    global cached_channels, cached_epg
+    cached_channels = channels
+    cached_epg = epg
 
 # Track currently playing marker (server-side)
 CURRENTLY_PLAYING = None
@@ -833,6 +955,131 @@ def apply_epg_fallback(channels, epg):
                 'stop': None
             }]
     return epg
+
+
+# ------------------- EPG Disk Cache -------------------
+
+def _epg_cache_path(tuner_name: str) -> str:
+    """Return the absolute path of the on-disk EPG cache file for a given tuner.
+
+    Sanitisation strips all characters that could form path components, so the
+    result is always a plain filename with no directory component.  A final
+    canonical path check provides defence-in-depth.
+    """
+    # Replace every character that is not alphanumeric, underscore, or hyphen
+    # with '_'.  This removes all path separators, dots (dot-dot traversal),
+    # and other shell-special characters before they reach any file-system call.
+    safe_name = re.sub(r'[^a-zA-Z0-9_-]', '_', tuner_name)
+    if not safe_name:
+        raise ValueError(f"Tuner name {tuner_name!r} results in an empty safe filename")
+    safe_dir = os.path.normpath(os.path.abspath(EPG_CACHE_DIR))
+    # Join the validated directory with the sanitised filename only — never with
+    # the raw tuner_name.
+    path = os.path.normpath(os.path.join(safe_dir, safe_name + ".json"))
+    # Defence-in-depth: verify the resolved path is strictly within the cache dir.
+    if not path.startswith(safe_dir + os.sep):
+        raise ValueError(f"Tuner name {tuner_name!r} would escape the cache directory")
+    return path
+
+
+def _serialize_epg(epg: dict) -> dict:
+    """Convert EPG dict (containing datetime values) to a JSON-serializable form."""
+    result = {}
+    for cid, programs in epg.items():
+        serialized = []
+        for prog in programs:
+            p = dict(prog)
+            for key in ('start', 'stop'):
+                val = p.get(key)
+                p[key] = val.isoformat() if val is not None else None
+            serialized.append(p)
+        result[cid] = serialized
+    return result
+
+
+def _deserialize_epg(data: dict) -> dict:
+    """Restore datetime objects in an EPG dict loaded from JSON."""
+    result = {}
+    for cid, programs in data.items():
+        restored = []
+        for prog in programs:
+            p = dict(prog)
+            for key in ('start', 'stop'):
+                val = p.get(key)
+                if val is not None:
+                    try:
+                        p[key] = datetime.fromisoformat(val)
+                    except (ValueError, TypeError):
+                        p[key] = None
+                else:
+                    p[key] = None
+            restored.append(p)
+        result[cid] = restored
+    return result
+
+
+def _load_epg_from_disk(tuner_name: str, max_age: float | None = EPG_DISK_CACHE_TTL) -> dict | None:
+    """Load EPG from disk cache if the file exists and is within max_age seconds old.
+
+    Args:
+        tuner_name: Name of the tuner whose EPG to load.
+        max_age: Maximum cache age in seconds.  Pass ``None`` to load regardless
+                 of age (stale-fallback mode).  Defaults to ``EPG_DISK_CACHE_TTL``.
+
+    Returns:
+        Restored EPG dict on success, ``None`` if the file is missing, stale, or
+        corrupt.
+    """
+    try:
+        path = _epg_cache_path(tuner_name)
+        if not os.path.isfile(path):
+            return None
+        if max_age is not None:
+            age = time.time() - os.path.getmtime(path)
+            if age > max_age:
+                logging.debug(
+                    "_load_epg_from_disk: cache stale for tuner %r (age=%.1fh)",
+                    tuner_name, age / 3600,
+                )
+                return None
+        with open(path, 'r', encoding='utf-8') as fh:
+            raw = _json.load(fh)
+        epg = _deserialize_epg(raw)
+        logging.debug(
+            "_load_epg_from_disk: loaded %d EPG channel(s) for tuner %r from cache",
+            len(epg), tuner_name,
+        )
+        return epg
+    except ValueError:
+        return None
+    except Exception:
+        logging.warning(
+            "_load_epg_from_disk: failed to read cache for tuner %r",
+            tuner_name, exc_info=True,
+        )
+        return None
+
+
+def _save_epg_to_disk(tuner_name: str, epg: dict) -> None:
+    """Persist an EPG dict to disk so app restarts skip the XMLTV re-fetch."""
+    try:
+        path = _epg_cache_path(tuner_name)
+    except ValueError:
+        logging.warning("_save_epg_to_disk: refusing unsafe path for tuner %r", tuner_name)
+        return
+    try:
+        os.makedirs(EPG_CACHE_DIR, exist_ok=True)
+        with open(path, 'w', encoding='utf-8') as fh:
+            _json.dump(_serialize_epg(epg), fh)
+        logging.debug(
+            "_save_epg_to_disk: saved %d EPG channel(s) for tuner %r",
+            len(epg), tuner_name,
+        )
+    except Exception:
+        logging.warning(
+            "_save_epg_to_disk: failed to write cache for tuner %r",
+            tuner_name, exc_info=True,
+        )
 
 
 # ------------------- Virtual Channels -------------------
@@ -4585,12 +4832,13 @@ def guide():
     user_prefs = get_user_prefs(current_user.username)
     user_default_theme = user_prefs.get("default_theme") or None
 
+    effective_tuner, tuner_channels, tuner_epg = get_request_tuner_data()
     virtual_ch = get_virtual_channels()
     vc_settings = get_virtual_channel_settings()
     virtual_ch = [ch for ch in virtual_ch if vc_settings.get(ch['tvg_id'], True)]
     virtual_epg = get_virtual_epg(grid_start, HOURS_SPAN)
-    all_channels = virtual_ch + cached_channels
-    all_epg = {**virtual_epg, **cached_epg}
+    all_channels = virtual_ch + tuner_channels
+    all_epg = {**virtual_epg, **tuner_epg}
 
     return render_template(
         'guide.html',
@@ -4602,7 +4850,7 @@ def guide():
         SCALE=SCALE,
         total_width=total_width,
         now_offset=now_offset,
-        current_tuner=get_current_tuner(),
+        current_tuner=effective_tuner,
         user_prefs=user_prefs,
         user_default_theme=user_default_theme,
         overlay_appearance=get_overlay_appearance(),
@@ -4764,7 +5012,8 @@ def api_channels():
     Return JSON list of cached channels for remote UIs.
     """
     out = []
-    for ch in cached_channels:
+    _, tuner_channels, _ = get_request_tuner_data()
+    for ch in tuner_channels:
         out.append({
             'tvg_id': ch.get('tvg_id'),
             'name': ch.get('name'),
@@ -4809,8 +5058,9 @@ def api_channel_health():
     # Cap batch size
     channel_ids = channel_ids[:_HEALTH_CHECK_MAX_BATCH]
 
-    # Build a lookup from tvg_id → url using the live channel cache
-    url_map = {ch.get("tvg_id"): ch.get("url", "") for ch in cached_channels}
+    # Build a lookup from tvg_id → url using the current user's effective tuner.
+    _, tuner_channels, _ = get_request_tuner_data()
+    url_map = {ch.get("tvg_id"): ch.get("url", "") for ch in tuner_channels}
 
     def _check_one(cid):
         url = url_map.get(cid, "")
@@ -5260,6 +5510,9 @@ def api_weather_bg_override():
     POST → body JSON {"condition": "<value>"}  sets override; "" or "auto" clears it.
     DELETE → clears the override (sets to "").
     """
+    if not _is_admin_user():
+        return jsonify({'ok': False, 'error': 'Admin only'}), 403
+
     if request.method == 'GET':
         cfg = get_weather_config()
         return jsonify({'condition': cfg.get('bg_condition_override', '')})
@@ -5322,6 +5575,8 @@ def api_traffic_demo_cities():
 @login_required
 def api_traffic_demo_city_update(city_id):
     """Update enabled/weight for a single city (admin action)."""
+    if not _is_admin_user():
+        return jsonify({'ok': False, 'error': 'Admin only'}), 403
     data = request.get_json(silent=True) or {}
     enabled = bool(data.get('enabled', True))
     weight  = max(1, int(data.get('weight', 1)))
@@ -5337,6 +5592,8 @@ def api_traffic_demo_city_update(city_id):
 @login_required
 def api_traffic_demo_enable_all():
     """Enable all cities."""
+    if not _is_admin_user():
+        return jsonify({'ok': False, 'error': 'Admin only'}), 403
     set_all_traffic_demo_cities_enabled(True)
     return jsonify({'ok': True})
 
@@ -5345,6 +5602,8 @@ def api_traffic_demo_enable_all():
 @login_required
 def api_traffic_demo_disable_all():
     """Disable all cities."""
+    if not _is_admin_user():
+        return jsonify({'ok': False, 'error': 'Admin only'}), 403
     set_all_traffic_demo_cities_enabled(False)
     return jsonify({'ok': True})
 
@@ -5353,6 +5612,8 @@ def api_traffic_demo_disable_all():
 @login_required
 def api_traffic_demo_pick_random():
     """Randomly pick N cities and store as the rotation pack."""
+    if not _is_admin_user():
+        return jsonify({'ok': False, 'error': 'Admin only'}), 403
     data = request.get_json(silent=True) or {}
     demo_cfg = get_traffic_demo_config()
     n = int(data.get('pack_size', demo_cfg.get('pack_size', 10)))
@@ -5908,18 +6169,19 @@ def api_current_program():
         return jsonify({"ok": False, "error": "missing tvg_id or id"}), 400
 
     try:
+        _, tuner_channels, tuner_epg = get_request_tuner_data()
         now = datetime.now(timezone.utc)
         # find channel name and logo
         channel_name = None
         channel_logo = ''
-        for ch in cached_channels:
+        for ch in tuner_channels:
             if ch.get('tvg_id') == tvg_id or str(ch.get('number')) == str(tvg_id):
                 channel_name = ch.get('name')
                 channel_logo = ch.get('logo') or ''
                 break
 
         # get epg entries for tvg_id
-        programs = cached_epg.get(tvg_id) or []
+        programs = tuner_epg.get(tvg_id) or []
         current_prog = None
         for prog in programs:
             start = prog.get('start')
@@ -5992,13 +6254,14 @@ def api_whats_on_now():
     """
     try:
         now = datetime.now(timezone.utc)
+        _, tuner_channels, tuner_epg = get_request_tuner_data()
         virtual_ch = get_virtual_channels()
         vc_settings = get_virtual_channel_settings()
         virtual_ch = [ch for ch in virtual_ch if vc_settings.get(ch.get('tvg_id', ''), True)]
         grid_start = now.replace(minute=(0 if now.minute < 30 else 30), second=0, microsecond=0)
         virtual_epg = get_virtual_epg(grid_start, HOURS_SPAN)
-        all_channels = virtual_ch + cached_channels
-        all_epg = {**virtual_epg, **cached_epg}
+        all_channels = virtual_ch + tuner_channels
+        all_epg = {**virtual_epg, **tuner_epg}
 
         out = []
         for ch in all_channels:
@@ -6451,13 +6714,14 @@ def refresh_current_tuner(tuner_name=None):
 
         # Use load_tuner_data so combined tuners (which have no direct m3u/xml)
         # are handled correctly by merging their source tuners' feeds.
-        new_channels, new_epg = load_tuner_data(tuner_name)
+        # force_refresh=True bypasses the disk cache so we always fetch fresh data.
+        new_channels, new_epg = load_tuner_data(tuner_name, force_refresh=True)
         new_epg = apply_epg_fallback(new_channels, new_epg)
 
-        # atomic swap
-        global cached_channels, cached_epg
-        cached_channels = new_channels
-        cached_epg = new_epg
+        # Only replace the in-memory guide when refreshing the active tuner.
+        # Other tuner refreshes are used to rebuild their on-disk JSON cache.
+        if tuner_name == get_current_tuner():
+            _set_cached_tuner_data(new_channels, new_epg)
 
         now_iso = datetime.now(timezone.utc).isoformat()
         set_setting(f"last_auto_refresh:{tuner_name}", f"success|{now_iso}")
@@ -6475,6 +6739,31 @@ def refresh_current_tuner(tuner_name=None):
             _release_lock(tuner_name)
         except Exception:
             pass
+
+
+@app.route('/api/auto_refresh/trigger', methods=['POST'])
+@login_required
+def api_auto_refresh_trigger():
+    """Force-refresh a tuner's guide data and JSON cache."""
+    if not _is_admin_user():
+        return jsonify({"ok": False, "error": "Unauthorized"}), 403
+
+    payload = request.get_json(silent=True) or {}
+    tuner_name = (
+        payload.get("tuner")
+        or request.form.get("tuner")
+        or request.args.get("tuner")
+        or get_current_tuner()
+    )
+    tuner_name = tuner_name.strip() if isinstance(tuner_name, str) else ""
+    if not tuner_name:
+        return jsonify({"ok": False, "error": "No tuner specified"}), 400
+
+    if tuner_name not in get_tuners():
+        return jsonify({"ok": False, "error": "Unknown tuner"}), 404
+
+    ok = refresh_current_tuner(tuner_name)
+    return jsonify({"ok": ok, "tuner": tuner_name})
 
 def refresh_if_due(tuner_name=None):
     """Check settings and last-run timestamp; refresh if interval elapsed."""

--- a/blueprints/admin_diagnostics.py
+++ b/blueprints/admin_diagnostics.py
@@ -458,8 +458,12 @@ def diagnostics_stream_detect():
             return jsonify({"error": "Invalid URL scheme — only http/https/rtmp are supported."}), 400
 
     from utils.stream_detect import detect_stream_type  # noqa: PLC0415
-    result = detect_stream_type(url)
-    return jsonify(result)
+    try:
+        result = detect_stream_type(url)
+        return jsonify(result)
+    except Exception as exc:  # noqa: BLE001
+        logger.exception("stream-detect: unexpected probe failure for %r: %s", url, exc)
+        return jsonify({"error": "Stream detection failed. Check server logs for details."}), 500
 
 
 @admin_diagnostics_bp.route("/tuner-sources", methods=["GET"])

--- a/retroiptv_linux.sh
+++ b/retroiptv_linux.sh
@@ -3,7 +3,7 @@
 # License: Creative Commons Attribution-NonCommercial-ShareAlike 4.0 International (CC BY-NC-SA 4.0)
 
 set -euo pipefail
-VERSION="4.9.7"
+VERSION="4.9.8"
 TIMESTAMP=$(date +"%Y-%m-%d_%H-%M-%S")
 LOGFILE="retroiptv_${TIMESTAMP}.log"
 exec > >(tee -a "$LOGFILE") 2>&1

--- a/retroiptv_linux.sh
+++ b/retroiptv_linux.sh
@@ -40,7 +40,8 @@ done
 [[ $(id -u) -ne 0 ]] && { echo "Run as root (sudo)."; exit 1; }
 
 APP_USER="iptv"; APP_HOME="/home/$APP_USER"; APP_DIR=""
-SERVICE_NAME="iptv-server"; SYSTEMD_FILE="/etc/systemd/system/${SERVICE_NAME}.service"
+SERVICE_NAME="retroiptvguide"; SYSTEMD_FILE="/etc/systemd/system/${SERVICE_NAME}.service"
+LEGACY_SERVICE_NAME="iptv-server"; LEGACY_SYSTEMD_FILE="/etc/systemd/system/${LEGACY_SERVICE_NAME}.service"
 LOG_DIR_LINUX="/var/log/iptv"
 
 # --- OS detection ------------------------------------------------------------
@@ -85,8 +86,8 @@ agree_terms() {
   echo "      * Copy project files into /opt/retroiptvguide (Fedora/RHEL)"
   echo "      * Create and configure a Python virtual environment"
   echo "      * Upgrade pip and install requirements"
-  echo "      * Create and enable the iptv-server systemd service"
-  echo "      * Start the iptv-server service"
+  echo "      * Create and enable the retroiptvguide systemd service"
+  echo "      * Start the retroiptvguide service"
   echo ""
   echo "By continuing, you acknowledge and agree that:"
   echo "  - This software should ONLY be run on internal networks."
@@ -195,6 +196,65 @@ WantedBy=multi-user.target
 EOF
 }
 
+# Returns 0 (true) if RetroStation MC — or any other non-RetroIPTVGuide service
+# that runs as the shared 'iptv' user — is detected on this system.
+# Checks in three ways:
+#   1. Known RetroStation MC systemd service names
+#   2. Any systemd unit file that sets User=iptv but is not owned by us
+#   3. Known RetroStation MC install directories under /home/iptv
+retrostation_mc_is_present(){
+  # 1. Known service names
+  local rsmc_services=("retrostation-mc" "retrostation_mc" "retrostationmc" "retrostation")
+  for svc in "${rsmc_services[@]}"; do
+    [[ -f "/etc/systemd/system/${svc}.service" ]] && return 0
+  done
+
+  # 2. Any foreign service file that runs as the iptv user
+  local our_names=("$SERVICE_NAME" "$LEGACY_SERVICE_NAME")
+  while IFS= read -r -d '' svcfile; do
+    local svcname
+    svcname=$(basename "$svcfile" .service)
+    local is_ours=false
+    for ours in "${our_names[@]}"; do [[ "$svcname" == "$ours" ]] && is_ours=true && break; done
+    if [[ "$is_ours" == false ]] && grep -Eq '^[[:space:]]*User=iptv[[:space:]]*$' "$svcfile" 2>/dev/null; then
+      return 0
+    fi
+  done < <(find /etc/systemd/system -maxdepth 1 -name "*.service" -print0 2>/dev/null)
+
+  # 3. Known RetroStation MC directories
+  local rsmc_dirs=(
+    "/home/iptv/RetroStationMC"
+    "/home/iptv/retrostation-mc"
+    "/home/iptv/retrostation_mc"
+    "/home/iptv/retrostation"
+  )
+  for dir in "${rsmc_dirs[@]}"; do [[ -d "$dir" ]] && return 0; done
+
+  return 1
+}
+
+service_unit_belongs_to_retroiptvguide(){
+  local unit_file="$1"
+  [[ -f "$unit_file" ]] || return 1
+  grep -Fq "RetroIPTVGuide" "$unit_file" || \
+    grep -Eq '^[[:space:]]*WorkingDirectory=(/home/iptv/iptv-server|/opt/retroiptvguide)[[:space:]]*$' "$unit_file" || \
+    grep -Eq '^[[:space:]]*ExecStart=(/home/iptv/iptv-server|/opt/retroiptvguide)/venv/bin/(python|python3)([[:space:]]+-[^[:space:]]+)*[[:space:]]+app\.py([[:space:]].*)?$' "$unit_file"
+}
+
+cleanup_legacy_service_if_owned(){
+  [[ -f "$LEGACY_SYSTEMD_FILE" ]] || return 0
+
+  if service_unit_belongs_to_retroiptvguide "$LEGACY_SYSTEMD_FILE"; then
+    echo "Removing legacy $LEGACY_SERVICE_NAME service owned by RetroIPTVGuide..."
+    systemctl stop "$LEGACY_SERVICE_NAME" 2>/dev/null || true
+    systemctl disable "$LEGACY_SERVICE_NAME" 2>/dev/null || true
+    rm -f "$LEGACY_SYSTEMD_FILE"
+    systemctl daemon-reload
+  else
+    echo "Leaving legacy $LEGACY_SERVICE_NAME service untouched because it is not owned by RetroIPTVGuide."
+  fi
+}
+
 rhel_firewall_selinux(){
   [[ "$PKG_MANAGER" =~ dnf|yum ]] || return 0
   if systemctl is-active --quiet firewalld; then
@@ -220,6 +280,7 @@ start_and_verify(){
 install_linux(){
   agree_terms
   ensure_packages; ensure_user; clone_or_stage_project; make_venv_and_install; write_systemd_service
+  cleanup_legacy_service_if_owned
   rhel_firewall_selinux; start_and_verify
   echo "Installed to: $APP_DIR"
   echo "End time: $(date)"
@@ -242,6 +303,8 @@ update_linux(){
     sudo -u "$APP_USER" "$APP_DIR/venv/bin/pip" install --upgrade pip
     sudo -u "$APP_USER" "$APP_DIR/venv/bin/pip" install -r "$APP_DIR/requirements.txt"
   fi
+  write_systemd_service
+  cleanup_legacy_service_if_owned
   systemctl daemon-reload; systemctl restart "$SERVICE_NAME"
   echo "✅ Updated and restarted."
 }
@@ -251,6 +314,7 @@ uninstall_linux(){
   systemctl stop "$SERVICE_NAME" 2>/dev/null || true
   systemctl disable "$SERVICE_NAME" 2>/dev/null || true
   [[ -f "$SYSTEMD_FILE" ]] && rm -f "$SYSTEMD_FILE" && systemctl daemon-reload
+  cleanup_legacy_service_if_owned
 
   echo "Removing files..."
   rm -rf "$LOG_DIR_LINUX" 2>/dev/null || true
@@ -280,36 +344,53 @@ uninstall_linux(){
     semanage port -d -t http_port_t -p tcp 5000 2>/dev/null || true
   fi
 
-  echo "Removing user/group..."
+  echo "Checking for shared-user services (e.g. RetroStation MC)..."
+  if retrostation_mc_is_present; then
+    echo ""
+    echo "⚠️  RetroStation MC (or another service using the 'iptv' user) was detected."
+    echo "   Skipping removal of user '$APP_USER', group '$APP_USER', and home directory"
+    echo "   to avoid breaking that installation."
+    echo "   To fully remove the 'iptv' user, uninstall RetroStation MC first, then run:"
+    echo "     pkill -u $APP_USER 2>/dev/null || true"
+    echo "     userdel -r $APP_USER && groupdel $APP_USER"
+    SHARED_USER_PRESERVED=true
+  else
+    echo "Removing user/group..."
 
-# Stop processes that may still run as iptv
-pkill -u "$APP_USER" 2>/dev/null || true
+    # Stop processes that may still run as iptv
+    pkill -u "$APP_USER" 2>/dev/null || true
 
-# Remove system user and home directory if it exists
-if id "$APP_USER" &>/dev/null; then
-  echo " - Deleting user '$APP_USER' and home directory"
-  userdel -r "$APP_USER" 2>/dev/null || true
-else
-  echo " - User '$APP_USER' not found, skipping"
-fi
+    # Remove system user and home directory if it exists
+    if id "$APP_USER" &>/dev/null; then
+      echo " - Deleting user '$APP_USER' and home directory"
+      userdel -r "$APP_USER" 2>/dev/null || true
+    else
+      echo " - User '$APP_USER' not found, skipping"
+    fi
 
-# Remove group if it still exists
-if getent group "$APP_USER" >/dev/null 2>&1; then
-  echo " - Deleting group '$APP_USER'"
-  groupdel "$APP_USER" 2>/dev/null || true
-fi
+    # Remove group if it still exists
+    if getent group "$APP_USER" >/dev/null 2>&1; then
+      echo " - Deleting group '$APP_USER'"
+      groupdel "$APP_USER" 2>/dev/null || true
+    fi
 
+    SHARED_USER_PRESERVED=false
+  fi
 
   echo ""
   echo "============================================================"
   echo " Uninstallation Complete "
   echo "============================================================"
   echo "Removed:"
-  echo "  - Systemd service and unit file"
+  echo "  - RetroIPTVGuide systemd service and unit file"
   echo "  - Application directories (/opt/retroiptvguide or /home/iptv/iptv-server)"
   echo "  - Firewall rules (firewalld/UFW) for TCP 5000"
   echo "  - SELinux port context (if previously set)"
-  echo "  - User and group 'iptv'"
+  if [[ "${SHARED_USER_PRESERVED:-false}" == true ]]; then
+    echo "  - (User/group 'iptv' and home directory preserved — RetroStation MC detected)"
+  else
+    echo "  - User and group 'iptv'"
+  fi
   echo ""
   echo "✅ Uninstall complete. Full log saved to $LOGFILE."
 }

--- a/retroiptv_rpi.sh
+++ b/retroiptv_rpi.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-VERSION="4.9.7"
+VERSION="4.9.8"
 # RetroIPTVGuide Raspberry Pi Installer (Headless, Pi3/4/5)
 # Installs to /home/iptv/iptv-server for consistency with Debian/Windows
 # Logs to /var/log/retroiptvguide/install-YYYYMMDD-HHMMSS.log

--- a/retroiptv_rpi.sh
+++ b/retroiptv_rpi.sh
@@ -77,6 +77,33 @@ set_gpu_mem() {
 ensure_owned_by_iptv() { sudo chown -R "$APP_USER:$APP_USER" "$APP_DIR"; }
 pip_install_as_iptv()   { sudo -u "$APP_USER" bash -lc "$1"; }
 
+# Returns 0 (true) if RetroStation MC — or any other non-RetroIPTVGuide service
+# that runs as the shared 'iptv' user — is detected on this system.
+retrostation_mc_is_present(){
+  local rsmc_services=("retrostation-mc" "retrostation_mc" "retrostationmc" "retrostation")
+  for svc in "${rsmc_services[@]}"; do
+    [ -f "/etc/systemd/system/${svc}.service" ] && return 0
+  done
+
+  while IFS= read -r -d '' svcfile; do
+    local svcname
+    svcname=$(basename "$svcfile" .service)
+    if [ "$svcname" != "retroiptvguide" ] && grep -Eq '^[[:space:]]*User=iptv[[:space:]]*$' "$svcfile" 2>/dev/null; then
+      return 0
+    fi
+  done < <(find /etc/systemd/system -maxdepth 1 -name "*.service" -print0 2>/dev/null)
+
+  local rsmc_dirs=(
+    "/home/iptv/RetroStationMC"
+    "/home/iptv/retrostation-mc"
+    "/home/iptv/retrostation_mc"
+    "/home/iptv/retrostation"
+  )
+  for dir in "${rsmc_dirs[@]}"; do [ -d "$dir" ] && return 0; done
+
+  return 1
+}
+
 #====================== INSTALL ======================#
 install_app() {
   echo ""
@@ -296,6 +323,14 @@ uninstall_app() {
   systemctl stop retroiptvguide 2>/dev/null || true
   systemctl disable retroiptvguide 2>/dev/null || true
   [ -f "$SERVICE_FILE" ] && sudo rm -f "$SERVICE_FILE" && sudo systemctl daemon-reload
+
+  if retrostation_mc_is_present; then
+    echo ""
+    echo "⚠️  RetroStation MC (or another service using the 'iptv' user) was detected."
+    echo "   The 'iptv' user and home directory will NOT be removed to avoid breaking"
+    echo "   that installation. Only the RetroIPTVGuide app directory will be removed."
+    echo ""
+  fi
 
   if [ -d "$APP_DIR" ]; then
     if [ "$AUTO_YES" = true ]; then

--- a/retroiptv_windows.bat
+++ b/retroiptv_windows.bat
@@ -3,7 +3,7 @@ mode con: cols=160 lines=50
 
 REM ============================================================
 REM RetroIPTVGuide Windows Unified Installer / Uninstaller
-REM Version: v4.9.7
+REM Version: v4.9.8
 REM License: Creative Commons BY-NC-SA 4.0
 REM ============================================================
 
@@ -31,7 +31,7 @@ if /i "%choice%"=="Y" (
 
 :continue
 setlocal
-set "VERSION=4.9.7"
+set "VERSION=4.9.8"
 set "REPO_URL=https://github.com/thehack904/RetroIPTVGuide.git"
 set "ZIP_URL=https://github.com/thehack904/RetroIPTVGuide/archive/refs/heads/main.zip"
 set "INSTALL_DIR=%~dp0RetroIPTVGuide"

--- a/retroiptv_windows.ps1
+++ b/retroiptv_windows.ps1
@@ -1,7 +1,7 @@
 <# 
 RetroIPTVGuide Windows Installer/Uninstaller
 Filename: retroiptv_windows.ps1
-Version: 4.9.7
+Version: 4.9.8
 
 License: Creative Commons Attribution-NonCommercial-ShareAlike 4.0 International
 https://creativecommons.org/licenses/by-nc-sa/4.0/
@@ -55,7 +55,7 @@ if (-not ([Security.Principal.WindowsPrincipal] [Security.Principal.WindowsIdent
 $ErrorActionPreference = 'Stop'
 $PSDefaultParameterValues['Out-File:Encoding'] = 'utf8'
 
-$VERSION = "4.9.7"
+$VERSION = "4.9.8"
 $ScriptDir = Split-Path -Parent -Path $MyInvocation.MyCommand.Path
 Set-Location $ScriptDir
 

--- a/static/css/base.css
+++ b/static/css/base.css
@@ -765,6 +765,34 @@ body.ersatztv .time-header-fixed .left-spacer{background:var(--chan-col-bg);}
 body.ersatztv{--arrow-collapsed:"▶";--arrow-expanded:"▼";}
 
 
+/* RetroStation MC Theme */
+body.retrostation-mc{--timebar-bg:#0C0E29;--timebar-border:#223463;--timebar-color:#5AC4F3;--chan-col-bg:#0C0E29;--chan-col-width:250px;--now-line-color:#0FCCFC;background:#05070F;color:#C6C3E2;font-family:"Arial","Helvetica",sans-serif}
+body.retrostation-mc .header{background:#0FCCFC;color:#05070F;border-bottom:2px solid #223463}
+body.retrostation-mc .header .links>a,body.retrostation-mc .header .links>.dropdown>.dropbtn,body.retrostation-mc .header .links>span,body.retrostation-mc .header .links>div#clock{color:#05070F!important;font-weight:bold!important}
+body.retrostation-mc .header .links>a:hover,body.retrostation-mc .header .links>.dropdown:hover>.dropbtn{background:#5AC4F3!important;color:#05070F!important}
+body.retrostation-mc .dropdown-content,body.retrostation-mc .submenu-content{background:#0C0E29!important;border:1px solid #223463!important;box-shadow:0 4px 8px rgba(0,0,0,.6)!important}
+body.retrostation-mc .dropdown-content a,body.retrostation-mc .submenu-content li a{color:#C6C3E2!important;font-weight:bold!important}
+body.retrostation-mc .dropdown-content a:hover,body.retrostation-mc .submenu-content li a:hover{background:#223463!important;color:#0FCCFC!important}
+body.retrostation-mc .dropdown-content .submenu>a{color:#C6C3E2!important;padding-right:28px!important;position:relative}
+body.retrostation-mc .dropdown-content .submenu>a::after{content:"▸";position:absolute;right:10px;top:50%;transform:translateY(-50%);color:#5AC4F3}
+body.retrostation-mc .dropdown-content .submenu:hover>a{background:#223463!important;color:#0FCCFC!important}
+body.retrostation-mc .time-header-wrap,body.retrostation-mc .time-header-fixed{background:#0C0E29;color:#5AC4F3;border-bottom:2px solid #223463}
+body.retrostation-mc .time-cell{color:#5AC4F3;border-right:1px solid #223463;font-weight:bold}
+body.retrostation-mc .chan-col{background:#0C0E29;border-right:2px solid #223463;color:#C6C3E2}
+body.retrostation-mc .chan-header{background:#0C0E29;color:#C6C3E2;border-color:#223463}
+body.retrostation-mc .chan-name{color:#C6C3E2;border-color:#223463;font-weight:bold}
+body.retrostation-mc .grid-col{background:#05070F}
+body.retrostation-mc .program{background:#0C0E29;border:1px solid #EC32E6;color:#C6C3E2;border-radius:4px}
+body.retrostation-mc .program.now{background:#14164a!important;border-color:#0FCCFC!important;color:#fff!important;font-weight:bold!important;box-shadow:0 0 8px rgba(15,204,252,.3)!important}
+body.retrostation-mc .program:hover{background:#14164a;border-color:#0FCCFC}
+body.retrostation-mc .now-line,body.retrostation-mc .time-header-fixed .now-line{background:#0FCCFC;width:3px;box-shadow:0 0 6px #5AC4F3}
+body.retrostation-mc .summary,body.retrostation-mc #program-info{background:#0C0E29;color:#C6C3E2;border:1px solid #EC32E6;padding:12px;border-radius:6px;box-shadow:0 4px 12px rgba(0,0,0,.5)}
+body.retrostation-mc .summary h3,body.retrostation-mc #program-info h3{margin:0 0 6px 0;color:#0FCCFC}
+body.retrostation-mc .summary p,body.retrostation-mc #program-info p{margin:0;color:#C6C3E2}
+body.retrostation-mc #video{background:#000;border:1px solid #223463;border-radius:4px}
+body.retrostation-mc .footer{background:#8E16D4;color:#C6C3E2;border-top:2px solid #682175}
+body.retrostation-mc .time-header-fixed .left-spacer{background:#0C0E29;width:var(--chan-col-width,250px)!important;min-width:var(--chan-col-width,250px)!important;max-width:var(--chan-col-width,250px)!important}
+body.retrostation-mc{--arrow-collapsed:"▸";--arrow-expanded:"▾"}
 
 
 /* Theme-aware separator for tuner fly-outs */

--- a/static/css/base.css
+++ b/static/css/base.css
@@ -37,12 +37,34 @@ body.guide-page { overflow: hidden; }
   -webkit-font-smoothing: antialiased;
 }
 
-/* Non-guide pages (Logs, About, Tuner Management, etc.) need their own scroll since they
-   do not have an internal scroll container like .guide-outer.  display-size.js also sets
-   this at runtime, but the CSS rule ensures correct behavior even before that script runs
-   (e.g. when no displaySize preference is stored and the JS early-returns). */
-body:not(.guide-page) #appZoomRoot {
+/* Non-guide pages (Logs, About, Tuner Management, etc.) scroll inside #pageContent,
+   not inside #appZoomRoot.  #appZoomRoot stays overflow:hidden so that
+   position:sticky on .header works on all browsers (including iOS Safari, which
+   breaks sticky when any overflow axis on an ancestor is 'hidden'). */
+
+/* #pageContent is the scroll surface for all base.html-derived (non-guide) pages.
+   It fills the remaining flex space below the header and scrolls internally,
+   mirroring the role .guide-outer plays on the guide page. */
+#pageContent {
+  flex: 1;
+  min-height: 0;
+  overflow-x: hidden;
   overflow-y: auto;
+  -webkit-overflow-scrolling: touch;
+  overscroll-behavior-y: contain;
+  box-sizing: border-box;
+}
+
+/* On mobile, lock html/body so the browser does not try to show/hide the
+   address bar dynamically.  Dynamic toolbars can overlay the top of
+   #appZoomRoot and cover the header.  Locking overflow:hidden here prevents
+   that browser behaviour for all pages (guide already has this via
+   mobile-scroll-fix.css; non-guide pages need it here). */
+@media (max-width: 900px) {
+  html, body {
+    height: 100%;
+    overflow: hidden;
+  }
 }
 
 /* Authoritative Header + menus (single source of truth for site) */
@@ -53,7 +75,9 @@ body { font-family: Arial, sans-serif; margin:0; }
   justify-content: space-between;
   align-items: center;
   padding: 0 10px;
-  position: relative;
+  position: sticky;
+  top: 0;
+  flex-shrink: 0;
   z-index: 2000;
   box-shadow: none;
   background: #222;

--- a/static/css/mobile.css
+++ b/static/css/mobile.css
@@ -52,6 +52,12 @@ html, body {
 .mobile-nav .mobile-links a { color: inherit; text-decoration:none; display:block; padding:10px 6px; border-radius:4px; }
 .mobile-nav .mobile-links a:hover { background: rgba(255,255,255,0.06); }
 
+/* Hide the mobile summary toggle on desktop; only shown inside the @media block */
+#mobileSummaryToggle {
+  display: none;
+}
+
+
 /* --- Mobile UX breakpoints --- */
 @media (max-width: 900px) {
   /* header */
@@ -135,6 +141,49 @@ html, body {
     max-width: 100% !important;
     box-sizing: border-box;
     padding: 10px !important;
+    overflow: hidden;
+    /* 600px is a generous upper bound for the summary panel content height;
+       typical content (title + description + time) is well under 200px.
+       A large value is required for the max-height CSS transition trick to work
+       smoothly — if this ever proves too small, increase it. */
+    max-height: 600px;
+    transition: max-height 0.35s ease, padding 0.35s ease, opacity 0.35s ease;
+    opacity: 1;
+  }
+
+  /* Collapsed state: summary folds away entirely */
+  .player .summary.summary-collapsed {
+    max-height: 0 !important;
+    padding-top: 0 !important;
+    padding-bottom: 0 !important;
+    opacity: 0;
+    pointer-events: none;
+  }
+
+  /* Mobile-only toggle button between summary and video */
+  #mobileSummaryToggle {
+    display: flex;
+    order: 1;
+    align-items: center;
+    justify-content: center;
+    gap: 5px;
+    width: 100%;
+    background: rgba(255, 255, 255, 0.08);
+    border: 1px solid rgba(255, 255, 255, 0.15);
+    border-radius: 4px;
+    color: inherit;
+    font-size: 0.75em;
+    padding: 4px 10px;
+    cursor: pointer;
+    box-sizing: border-box;
+    flex-shrink: 0;
+    letter-spacing: 0.03em;
+    transition: background 0.2s;
+  }
+  #mobileSummaryToggle:hover,
+  #mobileSummaryToggle:focus {
+    background: rgba(255, 255, 255, 0.15);
+    outline: none;
   }
 
   /* Video player wrap must be block (not inline-block) so it stretches to the

--- a/static/js/display-size.js
+++ b/static/js/display-size.js
@@ -52,9 +52,12 @@
       root.style.position = 'fixed';
       root.style.top = '0';
       root.style.left = '0';
-      // Guide page uses its own internal scroll container (.guide-outer); all other pages
-      // (Logs, About, Tuner Management, etc.) need the zoom root itself to be scrollable.
-      root.style.overflow = document.body.classList.contains('guide-page') ? 'hidden' : 'auto';
+      // #appZoomRoot is always overflow:hidden.  On guide pages, .guide-outer
+      // is the internal scroll container.  On all other pages (base.html-derived),
+      // #pageContent is the internal scroll container.  Keeping #appZoomRoot
+      // hidden avoids the iOS Safari bug where overflow-x:hidden on an ancestor
+      // silently breaks position:sticky for all descendants.
+      root.style.overflow = 'hidden';
       if (scale < 1) {
         // Explicit px avoids 100%/vh resolution quirks when overflow:hidden is involved
         root.style.transform = 'scale(' + scale + ')';
@@ -151,7 +154,13 @@
       if (initStyle) initStyle.parentNode.removeChild(initStyle);
 
       var saved = localStorage.getItem(STORAGE_KEY);
-      if (!saved) return;
+      if (!saved) {
+        // No preference saved — apply 1.0× so that inline position/overflow
+        // styles are set on #appZoomRoot immediately and the CSS-only fallback
+        // is not relied on (important for browsers that cache the layout).
+        applyUiZoom(1.0);
+        return;
+      }
       var scale = ZOOM_PRESETS[saved] || 1.0;
       _scale = scale;
 

--- a/static/js/guide-refresh.js
+++ b/static/js/guide-refresh.js
@@ -3,8 +3,10 @@
   const ENDPOINT = '/api/guide_snapshot?hours=6';
   const REFRESH_INTERVAL_MIN = 30; // same cadence as Cairo
 
-  // Track whether a refresh was skipped because video was in fullscreen
+  // Track whether a refresh was skipped because video was playing
   let _pendingRefresh = false;
+  // Debounce handle for the deferred reload (guards against simultaneous events)
+  let _idleTimer = null;
 
   function isFullscreenActive() {
     return !!(
@@ -15,12 +17,22 @@
     );
   }
 
+  // Returns true if video is actively playing in any mode:
+  // fullscreen, embedded in the guide, or Picture-in-Picture.
+  function isVideoPlaying() {
+    if (isFullscreenActive()) return true;
+    if (document.pictureInPictureElement) return true;
+    const video = document.getElementById('video');
+    if (video && !video.paused && !video.ended) return true;
+    return false;
+  }
+
   async function refreshGuide() {
-    // Do not reload while video is playing in fullscreen — it kills the stream.
-    // Set a flag so we reload as soon as fullscreen is exited.
-    if (isFullscreenActive()) {
+    // Do not reload while video is playing in any mode — it kills the stream.
+    // Set a flag so we reload as soon as playback stops.
+    if (isVideoPlaying()) {
       _pendingRefresh = true;
-      console.log('[guide-refresh] Fullscreen active — deferring guide refresh.');
+      console.log('[guide-refresh] Video is playing — deferring guide refresh.');
       return;
     }
 
@@ -28,9 +40,6 @@
       const res = await fetch(ENDPOINT, { cache: 'no-store' });
       if (!res.ok) throw new Error(`HTTP ${res.status}`);
 
-      // You can either rebuild just the EPG grid, or simply reload the page
-      // depending on how your current guide is generated.
-      // For now, safest approach is a full reload:
       _pendingRefresh = false;
       window.location.reload();
     } catch (err) {
@@ -38,19 +47,65 @@
     }
   }
 
+  // Called whenever playback may have stopped; performs the deferred reload
+  // if one is pending and the video is no longer playing.
+  // Debounced with a stored timer ID so simultaneous events (e.g. `pause` +
+  // `leavepictureinpicture`) never schedule more than one reload, and to
+  // guard against false triggers during brief buffering pauses or channel
+  // switching where playback resumes within milliseconds.
+  function onVideoIdle() {
+    if (!_pendingRefresh) return;
+    clearTimeout(_idleTimer);
+    _idleTimer = setTimeout(() => {
+      _idleTimer = null;
+      if (_pendingRefresh && !isVideoPlaying()) {
+        _pendingRefresh = false;
+        console.log('[guide-refresh] Video stopped — running deferred guide refresh.');
+        window.location.reload();
+      }
+    }, 500);
+  }
+
+  // Called when the video resumes playing; cancels any pending idle reload to
+  // avoid false triggers during channel switching or brief buffering pauses.
+  function onVideoPlaying() {
+    clearTimeout(_idleTimer);
+    _idleTimer = null;
+  }
+
   // When the user exits fullscreen, perform the deferred reload if one is waiting.
   function onFullscreenChange() {
-    if (!isFullscreenActive() && _pendingRefresh) {
-      _pendingRefresh = false;
-      console.log('[guide-refresh] Fullscreen exited — running deferred guide refresh.');
-      window.location.reload();
-    }
+    if (!isFullscreenActive()) onVideoIdle();
   }
 
   document.addEventListener('fullscreenchange', onFullscreenChange);
   document.addEventListener('webkitfullscreenchange', onFullscreenChange);
   document.addEventListener('mozfullscreenchange', onFullscreenChange);
   document.addEventListener('MSFullscreenChange', onFullscreenChange);
+
+  // Attach pause/ended/playing listeners to the video element so a deferred
+  // refresh fires as soon as the user stops watching (covers embedded and
+  // popped-out modes). The #video element is a long-lived static element;
+  // a console warning is emitted if it is unexpectedly absent.
+  function attachVideoListeners() {
+    const video = document.getElementById('video');
+    if (!video) {
+      console.warn('[guide-refresh] #video element not found; video-playing guard inactive.');
+      return;
+    }
+    video.addEventListener('pause', onVideoIdle);
+    video.addEventListener('ended', onVideoIdle);
+    // If playback resumes within the debounce window, cancel the pending reload.
+    video.addEventListener('playing', onVideoPlaying);
+    // leavepictureinpicture fires on the video element, not the document.
+    video.addEventListener('leavepictureinpicture', onVideoIdle);
+  }
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', attachVideoListeners);
+  } else {
+    attachVideoListeners();
+  }
 
   // Run once every X minutes so the grid rolls forward with real time
   setInterval(refreshGuide, REFRESH_INTERVAL_MIN * 60 * 1000);

--- a/static/js/mini-guide.js
+++ b/static/js/mini-guide.js
@@ -1,23 +1,9 @@
 (function () {
   'use strict';
 
-  var MINI_GUIDE_ROW_COUNT = 7;
-  var MINI_GUIDE_AUTODISMISS_MS = 8000;
-  var MINI_GUIDE_TOGGLE_KEY = 'g';
-
-  var isOpen = false;
-  var selectedIndex = 0;
   var channels = [];
-  var dismissTimer = null;
-  var progressTimer = null;
-  var isHovering = false;
   var guideLayout = ((window.__initialUserPrefs || {}).guide_layout === 'mini') ? 'mini' : 'full';
   var pageRenderQueued = false;
-
-  function escapeCid(cid) {
-    if (typeof CSS !== 'undefined' && CSS.escape) return CSS.escape(cid);
-    return String(cid || '').replace(/[^a-zA-Z0-9._-]/g, '\\$&');
-  }
 
   function fmtTime(date) {
     return date.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' });
@@ -87,19 +73,6 @@
     });
   }
 
-  function selectedWindow() {
-    var count = Math.min(MINI_GUIDE_ROW_COUNT, channels.length);
-    var start = Math.max(0, selectedIndex - Math.floor(count / 2));
-    start = Math.min(start, Math.max(0, channels.length - count));
-    return channels.slice(start, start + count);
-  }
-
-  function setSelectedByCurrent() {
-    var cid = currentChannelId();
-    var found = channels.findIndex(function (channel) { return channel.cid === cid; });
-    selectedIndex = found >= 0 ? found : 0;
-  }
-
   function clearChildren(el) {
     while (el.firstChild) el.removeChild(el.firstChild);
   }
@@ -111,13 +84,12 @@
     row.className = 'mini-guide-row';
     row.id = (options.idPrefix || 'mg-row-') + channel.index;
     row.setAttribute('role', 'option');
-    row.setAttribute('aria-selected', (!options.disableSelection && channel.index === selectedIndex) ? 'true' : 'false');
+    row.setAttribute('aria-selected', 'false');
     row.dataset.index = String(channel.index);
     row.dataset.url = channel.url;
     row.dataset.cid = channel.cid;
     row.dataset.name = channel.name;
 
-    if (!options.disableSelection && channel.index === selectedIndex) row.classList.add('is-selected');
     if (channel.cid === currentChannelId()) row.classList.add('is-current');
 
     var num = document.createElement('div');
@@ -185,33 +157,12 @@
     row.appendChild(logoWrap);
     row.appendChild(main);
     row.addEventListener('click', function () {
-      selectedIndex = channel.index;
-      tuneSelected();
-    });
-    row.addEventListener('mouseenter', function () {
-      if (options.disableSelection) return;
-      selectedIndex = channel.index;
-      render();
+      if (channel.url && typeof window.playChannel === 'function') {
+        window.playChannel(channel.url, channel.cid, channel.name);
+      }
     });
 
     return row;
-  }
-
-  function render() {
-    var list = document.getElementById('mgChannelList');
-    if (!list) return;
-    collectChannels();
-    if (!channels.length) {
-      clearChildren(list);
-      return;
-    }
-    if (selectedIndex < 0 || selectedIndex >= channels.length) setSelectedByCurrent();
-
-    clearChildren(list);
-    selectedWindow().forEach(function (channel) {
-      list.appendChild(buildRow(channel));
-    });
-    list.setAttribute('aria-activedescendant', 'mg-row-' + selectedIndex);
   }
 
   function renderPageMiniGuide() {
@@ -232,7 +183,7 @@
     }
 
     channels.forEach(function (channel) {
-      list.appendChild(buildRow(channel, { idPrefix: 'mg-page-row-', disableSelection: true }));
+      list.appendChild(buildRow(channel, { idPrefix: 'mg-page-row-' }));
     });
   }
 
@@ -296,106 +247,7 @@
     applyGuideLayout(guideLayout === 'mini' ? 'full' : 'mini', true);
   }
 
-  function scheduleDismiss() {
-    cancelDismiss();
-    if (!isOpen || isHovering) return;
-    dismissTimer = setTimeout(closeMiniGuide, MINI_GUIDE_AUTODISMISS_MS);
-  }
-
-  function cancelDismiss() {
-    if (dismissTimer) {
-      clearTimeout(dismissTimer);
-      dismissTimer = null;
-    }
-  }
-
-  function resetIdleTimer() {
-    scheduleDismiss();
-  }
-
-  function openMiniGuide() {
-    var panel = document.getElementById('miniGuide');
-    if (!panel) return;
-    collectChannels();
-    setSelectedByCurrent();
-    isOpen = true;
-    panel.classList.add('is-open');
-    panel.setAttribute('aria-hidden', 'false');
-    render();
-    scheduleDismiss();
-    if (progressTimer) clearInterval(progressTimer);
-    progressTimer = setInterval(function () {
-      if (!isOpen) return;
-      render();
-    }, 15000);
-  }
-
-  function closeMiniGuide() {
-    var panel = document.getElementById('miniGuide');
-    if (!panel) return;
-    isOpen = false;
-    panel.classList.remove('is-open');
-    panel.setAttribute('aria-hidden', 'true');
-    cancelDismiss();
-    if (progressTimer) {
-      clearInterval(progressTimer);
-      progressTimer = null;
-    }
-  }
-
-  function toggleMiniGuide() {
-    if (isOpen) closeMiniGuide();
-    else openMiniGuide();
-  }
-
-  function moveSelection(delta) {
-    if (!channels.length) collectChannels();
-    if (!channels.length) return;
-    selectedIndex = Math.min(channels.length - 1, Math.max(0, selectedIndex + delta));
-    render();
-    resetIdleTimer();
-  }
-
-  function tuneSelected() {
-    var channel = channels[selectedIndex];
-    if (!channel || !channel.url || typeof window.playChannel !== 'function') return;
-    window.playChannel(channel.url, channel.cid, channel.name);
-    closeMiniGuide();
-  }
-
-  function shouldIgnoreShortcut(event) {
-    var tag = (document.activeElement || {}).tagName || '';
-    return tag === 'INPUT' || tag === 'TEXTAREA' || tag === 'SELECT' || tag === 'BUTTON' || event.ctrlKey || event.metaKey || event.altKey;
-  }
-
   function wire() {
-    var button = document.getElementById('miniGuideBtn');
-    var closeButton = document.getElementById('miniGuideClose');
-    var panel = document.getElementById('miniGuide');
-
-    if (button) {
-      button.addEventListener('click', function (event) {
-        event.stopPropagation();
-        toggleMiniGuide();
-      });
-    }
-    if (closeButton) {
-      closeButton.addEventListener('click', function () {
-        closeMiniGuide();
-      });
-    }
-    if (panel) {
-      panel.addEventListener('mouseenter', function () {
-        isHovering = true;
-        cancelDismiss();
-      });
-      panel.addEventListener('mouseleave', function () {
-        isHovering = false;
-        scheduleDismiss();
-      });
-      panel.addEventListener('mousemove', resetIdleTimer);
-    }
-
     ['toggleGuideLayout', 'mobileToggleGuideLayout'].forEach(function (id) {
       var layoutToggle = document.getElementById(id);
       if (!layoutToggle) return;
@@ -421,35 +273,9 @@
       if (input) input.addEventListener('change', schedulePageRender);
     });
 
-    document.addEventListener('keydown', function (event) {
-      if (shouldIgnoreShortcut(event)) return;
-      if (event.key && event.key.toLowerCase() === MINI_GUIDE_TOGGLE_KEY) {
-        event.preventDefault();
-        toggleMiniGuide();
-        return;
-      }
-      if (!isOpen) return;
-      if (event.key === 'ArrowUp') {
-        event.preventDefault();
-        moveSelection(-1);
-      } else if (event.key === 'ArrowDown') {
-        event.preventDefault();
-        moveSelection(1);
-      } else if (event.key === 'Enter') {
-        event.preventDefault();
-        tuneSelected();
-      } else if (event.key === 'Escape') {
-        event.preventDefault();
-        closeMiniGuide();
-      }
-    });
-
     applyGuideLayout(guideLayout, false);
   }
 
-  window.openMiniGuide = openMiniGuide;
-  window.closeMiniGuide = closeMiniGuide;
-  window.toggleMiniGuide = toggleMiniGuide;
   window.setGuideLayout = function (layout, persist) { applyGuideLayout(layout, persist !== false); };
   window.toggleGuideLayout = toggleGuideLayout;
   window.renderMiniGuidePage = renderPageMiniGuide;

--- a/static/js/mobile-player-adapt.js
+++ b/static/js/mobile-player-adapt.js
@@ -22,7 +22,11 @@
       const vh = window.innerHeight;
       const headerHeight = header ? Math.round(header.getBoundingClientRect().height) : 40;
       const fixedBarHeight = fixedBar ? Math.round(fixedBar.getBoundingClientRect().height) : 0;
-      const reserved = headerHeight + fixedBarHeight + 80; // 80px for summary + paddings/controls
+      // When the summary panel is collapsed on mobile, its height is effectively 0
+      const summary = document.getElementById('summary');
+      const summaryCollapsed = summary && summary.classList.contains('summary-collapsed');
+      const summaryHeight = summaryCollapsed ? 0 : (summary ? Math.round(summary.getBoundingClientRect().height) : 80);
+      const reserved = headerHeight + fixedBarHeight + summaryHeight + 24; // 24px for paddings/toggle
       // Give the video a max height that's the remaining viewport minus some buffer
       const maxH = Math.max(160, Math.round(vh - reserved));
       // Restrict to a reasonable share of viewport (so timeline remains reachable)

--- a/static/js/mobile-summary-fold.js
+++ b/static/js/mobile-summary-fold.js
@@ -1,0 +1,167 @@
+/**
+ * mobile-summary-fold.js
+ *
+ * On mobile (viewport ≤ 900 px) the program-info summary panel beneath the
+ * header can be folded away so the video and guide grid get more vertical
+ * room.  A thin toggle strip always remains visible so the user can re-open
+ * the panel at any time.
+ *
+ * Auto-collapse behaviour: once the video has been playing for
+ * AUTO_HIDE_DELAY_MS milliseconds without user interaction the panel
+ * collapses automatically.  The timer is reset whenever the user expands
+ * the panel, and it is cancelled while the video is paused.
+ */
+(function () {
+  'use strict';
+
+  var AUTO_HIDE_DELAY_MS = 60000; // 1 minute
+  var MOBILE_BREAKPOINT = 900;
+
+  var autoHideTimer = null;
+  var _initialized = false;
+
+  /* ── helpers ── */
+
+  function isMobile() {
+    return window.innerWidth <= MOBILE_BREAKPOINT;
+  }
+
+  function getSummary() {
+    return document.getElementById('summary');
+  }
+
+  function getToggle() {
+    return document.getElementById('mobileSummaryToggle');
+  }
+
+  function isCollapsed() {
+    var el = getSummary();
+    return el ? el.classList.contains('summary-collapsed') : false;
+  }
+
+  function updateToggleLabel(collapsed) {
+    var btn = getToggle();
+    if (!btn) return;
+    if (collapsed) {
+      btn.textContent = '\u25b2 Program Info'; // ▲
+      btn.setAttribute('aria-expanded', 'false');
+    } else {
+      btn.textContent = '\u25bc Hide Info'; // ▼
+      btn.setAttribute('aria-expanded', 'true');
+    }
+  }
+
+  /* ── collapse / expand ── */
+
+  function collapse(opts) {
+    if (!isMobile()) return;
+    var summary = getSummary();
+    if (!summary || isCollapsed()) return;
+    summary.classList.add('summary-collapsed');
+    updateToggleLabel(true);
+    clearAutoHideTimer();
+    // Let the video-height adaptor reclaim the freed space
+    window.dispatchEvent(new Event('resize'));
+  }
+
+  function expand() {
+    if (!isMobile()) return;
+    var summary = getSummary();
+    if (!summary) return;
+    summary.classList.remove('summary-collapsed');
+    updateToggleLabel(false);
+    clearAutoHideTimer();
+    window.dispatchEvent(new Event('resize'));
+  }
+
+  // Expose for external callers (e.g. playChannel re-expands summary on channel switch)
+  window.mobileSummaryExpand = expand;
+
+  /* ── auto-hide timer ── */
+
+  function clearAutoHideTimer() {
+    if (autoHideTimer) {
+      clearTimeout(autoHideTimer);
+      autoHideTimer = null;
+    }
+  }
+
+  function startAutoHideTimer() {
+    clearAutoHideTimer();
+    if (!isMobile() || isCollapsed()) return;
+    autoHideTimer = setTimeout(function () {
+      collapse();
+    }, AUTO_HIDE_DELAY_MS);
+  }
+
+  /* ── toggle button click ── */
+
+  function onToggleClick() {
+    if (isCollapsed()) {
+      expand();
+      // If video is still playing, restart the auto-hide countdown after manual re-open
+      var video = document.getElementById('video');
+      if (video && !video.paused) {
+        startAutoHideTimer();
+      }
+    } else {
+      collapse();
+    }
+  }
+
+  /* ── responsive: desktop ↔ mobile transitions ── */
+
+  function onResize() {
+    var summary = getSummary();
+    var toggle = getToggle();
+    if (!summary || !toggle) return;
+    if (!isMobile()) {
+      // Restore full summary on desktop; clear any pending timers
+      summary.classList.remove('summary-collapsed');
+      clearAutoHideTimer();
+    }
+  }
+
+  /* ── initialisation ── */
+
+  function init() {
+    if (_initialized) return;
+    _initialized = true;
+
+    var toggle = getToggle();
+    if (toggle) {
+      toggle.addEventListener('click', onToggleClick);
+    }
+
+    var video = document.getElementById('video');
+    if (video) {
+      // Start auto-hide countdown when video begins playing
+      video.addEventListener('play', function () {
+        if (isMobile()) {
+          startAutoHideTimer();
+        }
+      });
+      // Pause the countdown while the video is paused
+      video.addEventListener('pause', function () {
+        clearAutoHideTimer();
+      });
+      // When a new channel is selected playChannel() calls window.mobileSummaryExpand()
+      // which handles re-expansion. Here we only need to clear the auto-hide timer
+      // so it resets cleanly for the next stream.
+      video.addEventListener('emptied', function () {
+        clearAutoHideTimer();
+      });
+    }
+
+    window.addEventListener('resize', onResize);
+
+    // Ensure the toggle label reflects the initial (expanded) state
+    updateToggleLabel(false);
+  }
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', init);
+  } else {
+    init();
+  }
+})();

--- a/static/js/user-prefs.js
+++ b/static/js/user-prefs.js
@@ -64,11 +64,9 @@
     const hidden = prefs.hidden_channels || [];
     document.querySelectorAll('.guide-row[data-cid]').forEach(row => {
       const cid = row.dataset.cid;
-      if (hidden.includes(cid)) {
-        row.classList.add('chan-hidden');
-      } else {
-        row.classList.remove('chan-hidden');
-      }
+      const isHidden = hidden.includes(cid);
+      row.classList.toggle('chan-hidden', isHidden);
+      row.classList.toggle('chan-hidden-visible', isHidden && showingHidden);
     });
   }
 
@@ -440,6 +438,30 @@
     ctxTarget = null;
   }
 
+  function wireChannelContextMenus() {
+    document.querySelectorAll('.chan-name').forEach(function (el) {
+      if (el.__userPrefsCtxBound) return;
+      el.__userPrefsCtxBound = true;
+      el.addEventListener('contextmenu', function (e) {
+        e.preventDefault();
+        openCtxMenu(e.clientX, e.clientY, el);
+      });
+    });
+  }
+
+  function hasRelevantGuideMutation(mutations) {
+    return mutations.some(function (mutation) {
+      const nodes = Array.from(mutation.addedNodes || []).concat(Array.from(mutation.removedNodes || []));
+      return nodes.some(function (node) {
+        if (!node || node.nodeType !== 1) return false;
+        if (typeof node.matches === 'function' && (node.matches('.guide-row[data-cid]') || node.matches('.chan-name'))) {
+          return true;
+        }
+        return typeof node.querySelector === 'function' && !!node.querySelector('.guide-row[data-cid], .chan-name');
+      });
+    });
+  }
+
   // ─── Init ──────────────────────────────────────────────────────────────────
   function init() {
     applyHiddenChannels();
@@ -479,19 +501,19 @@
 
     var guideOuter = document.getElementById('guideOuter');
     if (guideOuter && typeof MutationObserver === 'function') {
-      var rowObserver = new MutationObserver(function () {
+      var rowObserver = new MutationObserver(function (mutations) {
+        if (!hasRelevantGuideMutation(mutations)) return;
+        applyHiddenChannels();
+        applyFavoriteChannels();
+        applyAutoLoadMarker();
+        wireChannelContextMenus();
         scheduleChannelNumbersReapply();
       });
-      rowObserver.observe(guideOuter, { childList: true });
+      rowObserver.observe(guideOuter, { childList: true, subtree: true });
     }
 
     // Right-click context menu on channel names
-    document.querySelectorAll('.chan-name').forEach(function (el) {
-      el.addEventListener('contextmenu', function (e) {
-        e.preventDefault();
-        openCtxMenu(e.clientX, e.clientY, el);
-      });
-    });
+    wireChannelContextMenus();
 
     // Close context menu on outside click / scroll / Escape
     document.addEventListener('click', function (e) {

--- a/templates/_header.html
+++ b/templates/_header.html
@@ -80,6 +80,7 @@
                       <li><a href="#" data-theme-selector data-theme="comcast">Comcast</a></li>
                       <li><a href="#" data-theme-selector data-theme="classic-cable">Classic Cable</a></li>
                       <li><a href="#" data-theme-selector data-theme="ersatztv" title="Inspired by ErsatzTV">Icon Guide</a></li>
+                      <li><a href="#" data-theme-selector data-theme="retrostation-mc">RetroStation MC</a></li>
                     </ul>
                   </li>
                   <li class="submenu">
@@ -271,6 +272,7 @@
                   <li role="none"><a role="menuitem" href="#" data-theme-selector data-theme="comcast">Comcast</a></li>
                   <li role="none"><a role="menuitem" href="#" data-theme-selector data-theme="classic-cable">Classic Cable</a></li>
                   <li role="none"><a role="menuitem" href="#" data-theme-selector data-theme="ersatztv" title="Inspired by ErsatzTV">Icon Guide</a></li>
+                  <li role="none"><a role="menuitem" href="#" data-theme-selector data-theme="retrostation-mc">RetroStation MC</a></li>
                 </ul>
               </li>
               <li class="mobile-submenu" role="none">

--- a/templates/base.html
+++ b/templates/base.html
@@ -87,7 +87,6 @@
     <!-- Mobile-specific overrides / responsive styles (loaded after base.css) -->
     <link rel="stylesheet" href="{{ url_for('static', filename='css/mobile.css') }}">
     <link rel="stylesheet" href="{{ url_for('static', filename='css/mobile-submenu.css') }}">
-    <link rel="stylesheet" href="{{ url_for('static', filename='css/mobile-scroll-fix.css') }}">
 
     {% block page_styles %}
     {# per-page CSS variables or small style blocks can be provided here #}
@@ -97,9 +96,11 @@
     <div id="appZoomRoot">
     {% include '_header.html' %}
 
+    <div id="pageContent">
     {% block content %}
     <!-- Page-specific content goes here -->
     {% endblock %}
+    </div><!-- #pageContent -->
     </div><!-- #appZoomRoot -->
 
     <!-- shared scripts -->

--- a/templates/change_tuner.html
+++ b/templates/change_tuner.html
@@ -45,7 +45,7 @@
                   {% endfor %}
                 </select>
                 <button type="submit" class="primary">Set Active</button>
-                <button type="button" class="secondary" id="btn-run-now">Run Sync Now</button>
+                <button type="button" class="secondary" id="btn-run-now">Refresh JSON Cache</button>
               </form>
             </div>
             <div class="last-sync-box">
@@ -362,10 +362,20 @@ document.addEventListener('DOMContentLoaded', () => {
   const runNow = document.getElementById('btn-run-now');
   if (runNow) {
     runNow.addEventListener('click', () => {
-      fetch('/api/auto_refresh/trigger', { method: 'POST', credentials: 'same-origin' })
-        .then(r => r.json().catch(()=>({ok:false})))
-        .then(j => { alert(j && j.ok ? 'Refresh started' : 'Refresh request sent.'); })
-        .catch(()=>alert('Refresh request failed.'));
+      const tunerSelect = document.getElementById('tuner');
+      const tuner = tunerSelect ? tunerSelect.value : '';
+      fetch('/api/auto_refresh/trigger', {
+        method: 'POST',
+        credentials: 'same-origin',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ tuner })
+      })
+        .then(r => r.json().catch(() => ({ ok: false, tuner: tuner || null, error: 'Invalid response' })))
+        .then(j => {
+          const name = (j && j.tuner) ? j.tuner : (tuner || 'the selected tuner');
+          alert(j && j.ok ? `Refreshed JSON cache for ${name}.` : (j && j.error ? j.error : 'Refresh request failed.'));
+        })
+        .catch(() => alert('Refresh request failed.'));
     });
   }
 

--- a/templates/guide.html
+++ b/templates/guide.html
@@ -2264,7 +2264,7 @@ function applyThemeGuide(theme){
     const wasCC=b.classList.contains("classic-cable");
     const wasIconGuide=b.classList.contains("ersatztv");
     b.classList.remove("light","dark","retro-tvguide","retro-aol","retro-webtv",
-                       "retro-tvguide2000","retro-magazine","directv","comcast","tvguide1990","classic-cable","retroiptv","ersatztv");
+                       "retro-tvguide2000","retro-magazine","directv","comcast","tvguide1990","classic-cable","retroiptv","ersatztv","retrostation-mc");
     if (theme) b.classList.add(theme);
     try { localStorage.setItem('theme', theme); } catch (e) {}
     if((wasTVG || wasCC) && theme !== "tvguide1990" && theme !== "classic-cable") {

--- a/templates/guide.html
+++ b/templates/guide.html
@@ -2149,6 +2149,7 @@ function initGuideSearchFilter() {
 
         const searchChunks = [
             chanEl ? (chanEl.dataset.name || '') : '',
+            chanEl ? (chanEl.dataset.chanNum || '') : '',
             row.dataset.group || '',
             types.join(' '),
         ];

--- a/templates/guide.html
+++ b/templates/guide.html
@@ -320,7 +320,6 @@
     /* Mute button sits to the left of the FS button */
     #vcMuteBtn { right: 48px; }
     #chanInfoBtn { right: 88px; }
-    #miniGuideBtn { right: 128px; }
     /* Fill wrapper + overlay when in fullscreen (fallback for overlay types without a standalone page) */
     #videoPlayerWrap:fullscreen,
     #videoPlayerWrap:-webkit-full-screen {
@@ -539,64 +538,7 @@
         text-overflow: ellipsis;
         line-height: 1.3;
     }
-    /* ── Mini Guide ────────────────────────────────────────────────────────── */
-    .mini-guide {
-        position: absolute;
-        top: 50%;
-        left: 12px;
-        z-index: 35;
-        width: min(520px, calc(100% - 24px));
-        max-height: calc(100% - 24px);
-        color: #fff;
-        background: rgba(8, 10, 14, 0.82);
-        border: 1px solid rgba(255,255,255,0.18);
-        border-radius: 6px;
-        box-shadow: 0 14px 36px rgba(0,0,0,0.45);
-        backdrop-filter: blur(6px);
-        transform: translate(-110%, -50%);
-        opacity: 0;
-        pointer-events: none;
-        transition: transform 0.22s ease, opacity 0.22s ease;
-        overflow: hidden;
-        font-family: Arial, Helvetica, sans-serif;
-    }
-    .mini-guide.is-open {
-        transform: translate(0, -50%);
-        opacity: 1;
-        pointer-events: auto;
-    }
-    .mini-guide-header {
-        display: flex;
-        align-items: center;
-        justify-content: space-between;
-        gap: 12px;
-        padding: 9px 12px;
-        border-bottom: 1px solid rgba(255,255,255,0.12);
-        background: rgba(0,0,0,0.22);
-    }
-    .mini-guide-title {
-        font-size: 0.86em;
-        font-weight: 700;
-        letter-spacing: 0.04em;
-        text-transform: uppercase;
-    }
-    .mini-guide-close {
-        width: 28px;
-        height: 28px;
-        border: none;
-        border-radius: 4px;
-        color: #fff;
-        background: rgba(255,255,255,0.12);
-        cursor: pointer;
-        line-height: 1;
-    }
-    .mini-guide-close:hover { background: rgba(255,255,255,0.22); }
-    .mini-guide-list {
-        display: flex;
-        flex-direction: column;
-        padding: 6px;
-        gap: 4px;
-    }
+    /* ── Mini Guide Layout ─────────────────────────────────────────────────── */
     .mini-guide-row {
         display: grid;
         grid-template-columns: 46px 34px minmax(0, 1fr);
@@ -611,8 +553,7 @@
         text-align: left;
         cursor: pointer;
     }
-    .mini-guide-row:hover,
-    .mini-guide-row.is-selected {
+    .mini-guide-row:hover {
         border-color: rgba(80, 170, 255, 0.9);
         background: rgba(42, 116, 202, 0.42);
     }
@@ -811,6 +752,8 @@
         <h3>Program Info</h3>
         <p>Click a channel on the left to start playback.</p>
     </div>
+    <!-- Mobile-only toggle to collapse/expand the program info summary -->
+    <button id="mobileSummaryToggle" class="mobile-summary-toggle" aria-expanded="true" aria-controls="summary" title="Toggle program info">▼ Hide Info</button>
     <div id="retroRemoteOverlay" class="retro-remote-overlay" role="dialog" aria-modal="false" aria-label="Retro remote">
         <div class="retro-remote-shell">
             <div class="retro-remote-head">
@@ -860,7 +803,6 @@
         <button id="vcMuteBtn" class="vc-fs-btn" hidden aria-label="Mute virtual channel" title="Mute">🔇</button>
         <button id="vcFsBtn" class="vc-fs-btn" hidden aria-label="Toggle fullscreen" title="Fullscreen">⛶</button>
         <button id="chanInfoBtn" class="vc-fs-btn cib-toggle-btn" hidden aria-label="Toggle channel info" title="Channel Info">ℹ</button>
-        <button id="miniGuideBtn" class="vc-fs-btn" hidden aria-label="Toggle mini guide" title="Mini Guide">☰</button>
         <!-- Channel Info Banner: slides up from bottom of the video player on channel select -->
         <div id="channelInfoBanner" class="channel-info-banner" aria-live="polite" aria-atomic="true" style="display:none;">
             <div class="cib-inner">
@@ -883,13 +825,6 @@
                     <div id="cibDesc" class="cib-desc"></div>
                 </div>
             </div>
-        </div>
-        <div id="miniGuide" class="mini-guide" role="dialog" aria-modal="false" aria-label="Mini guide" aria-hidden="true">
-            <div class="mini-guide-header">
-                <div class="mini-guide-title">Mini Guide</div>
-                <button id="miniGuideClose" class="mini-guide-close" type="button" aria-label="Close mini guide">✕</button>
-            </div>
-            <div id="mgChannelList" class="mini-guide-list" role="listbox" aria-label="Channels near current channel"></div>
         </div>
         <div id="virtual-overlay-root" class="hidden" aria-hidden="true"></div>
     </div>
@@ -1079,8 +1014,6 @@ function _scheduleVcFsHide(delay) {
         if (mb && !mb.hidden) mb.classList.add('vc-fs-btn-fade');
         const ib = document.getElementById('chanInfoBtn');
         if (ib && !ib.hidden) ib.classList.add('vc-fs-btn-fade');
-        const mgb = document.getElementById('miniGuideBtn');
-        if (mgb && !mgb.hidden) mgb.classList.add('vc-fs-btn-fade');
     }, delay);
 }
 
@@ -1158,11 +1091,6 @@ function showVcFsBtn() {
         ib.hidden = !currentChannelId;
         ib.classList.remove('vc-fs-btn-fade');
     }
-    const mgb = document.getElementById('miniGuideBtn');
-    if (mgb) {
-        mgb.hidden = !currentChannelId;
-        mgb.classList.remove('vc-fs-btn-fade');
-    }
     _updateVcMuteBtn();
     _scheduleVcFsHide(3500);
 }
@@ -1172,11 +1100,6 @@ function showPlayerAuxBtns() {
     if (ib) {
         ib.hidden = !currentChannelId;
         ib.classList.remove('vc-fs-btn-fade');
-    }
-    const mgb = document.getElementById('miniGuideBtn');
-    if (mgb) {
-        mgb.hidden = !currentChannelId;
-        mgb.classList.remove('vc-fs-btn-fade');
     }
     _scheduleVcFsHide(3500);
 }
@@ -1192,9 +1115,6 @@ function hideVcFsBtn() {
     if (mb) { mb.hidden = true; mb.classList.remove('vc-fs-btn-fade'); }
     const ib = document.getElementById('chanInfoBtn');
     if (ib) { ib.hidden = true; ib.classList.remove('vc-fs-btn-fade'); }
-    const mgb = document.getElementById('miniGuideBtn');
-    if (mgb) { mgb.hidden = true; mgb.classList.remove('vc-fs-btn-fade'); }
-    if (typeof window.closeMiniGuide === 'function') window.closeMiniGuide();
     // Close iframe overlay if active when switching away from a virtual channel.
     const overlay = document.getElementById('vcFsOverlay');
     const iframe  = document.getElementById('vcFsIframe');
@@ -1432,15 +1352,12 @@ document.addEventListener('DOMContentLoaded', function () {
                 const mb = document.getElementById('vcMuteBtn');
                 if (mb && !mb.hidden) mb.classList.remove('vc-fs-btn-fade');
                 if (ib && !ib.hidden) ib.classList.remove('vc-fs-btn-fade');
-                const mgb = document.getElementById('miniGuideBtn');
-                if (mgb && !mgb.hidden) mgb.classList.remove('vc-fs-btn-fade');
                 _scheduleVcFsHide(1500);
             }
         });
         wrap.addEventListener('mouseleave', function () {
             const ib = document.getElementById('chanInfoBtn');
-            const mgb = document.getElementById('miniGuideBtn');
-            if (!btn.hidden || (ib && !ib.hidden) || (mgb && !mgb.hidden)) _scheduleVcFsHide(1500);
+            if (!btn.hidden || (ib && !ib.hidden)) _scheduleVcFsHide(1500);
         });
     }
 
@@ -1488,6 +1405,10 @@ function playChannel(url, cid, name) {
     // Expose currently-playing channel for user-prefs.js (auto-load / context menu)
     window.currentChannelMeta = { id: cid, name: name, url: url };
     updateSummary(cid, name);
+    // On mobile, re-expand the summary panel so the fresh program info is visible
+    if (typeof window.mobileSummaryExpand === 'function') {
+        window.mobileSummaryExpand();
+    }
     // Show the channel info banner on tune-in
     if (typeof window.showChannelInfoBanner === 'function') {
         window.showChannelInfoBanner(cid, name);
@@ -2819,6 +2740,8 @@ document.addEventListener('DOMContentLoaded', () => {
 <script src="{{ url_for('static', filename='js/grid-adapt.js') }}" defer></script>
 <!-- Mobile player adapt script: adjusts video height based on viewport/header/fixed-timebar -->
 <script src="{{ url_for('static', filename='js/mobile-player-adapt.js') }}" defer></script>
+<!-- Mobile summary fold: collapsible program info panel on mobile with auto-hide -->
+<script src="{{ url_for('static', filename='js/mobile-summary-fold.js') }}" defer></script>
 <!-- Video resize: drag handles for video/player/channel-column resizing -->
 <script src="{{ url_for('static', filename='js/video-resize.js') }}" defer></script>
 <!-- Mobile player adapt script: allow scrolling -->

--- a/templates/manage_users.html
+++ b/templates/manage_users.html
@@ -123,6 +123,7 @@
                         <option value="comcast"      {% if user.prefs.default_theme == 'comcast' %}selected{% endif %}>Comcast</option>
                         <option value="classic-cable" {% if user.prefs.default_theme == 'classic-cable' %}selected{% endif %}>Classic Cable</option>
                         <option value="ersatztv"     {% if user.prefs.default_theme == 'ersatztv' %}selected{% endif %}>Icon Guide</option>
+                        <option value="retrostation-mc" {% if user.prefs.default_theme == 'retrostation-mc' %}selected{% endif %}>RetroStation MC</option>
                       </select>
                     </div>
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,23 @@
+"""Shared pytest fixtures for the RetroIPTVGuide test suite."""
+import os
+import sys
+import tempfile
+
+import pytest
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+
+@pytest.fixture(autouse=True)
+def isolated_epg_cache(tmp_path):
+    """Redirect EPG_CACHE_DIR to a temporary directory for every test.
+
+    This prevents EPG cache files produced during one test from being picked
+    up by a later test that does not expect a pre-populated cache.
+    """
+    import app as app_module
+
+    orig = app_module.EPG_CACHE_DIR
+    app_module.EPG_CACHE_DIR = str(tmp_path / "epg_cache")
+    yield
+    app_module.EPG_CACHE_DIR = orig

--- a/tests/test_admin_diagnostics.py
+++ b/tests/test_admin_diagnostics.py
@@ -3999,6 +3999,48 @@ class TestStreamDetectEndpoint:
         data = json.loads(resp.data)
         assert data["stream_type"] == "Unknown"
 
+    def test_endpoint_returns_generic_error_on_exception(self, client, isolated_db, monkeypatch):
+        """Unexpected probe exceptions must not expose internal details to the caller."""
+        import utils.stream_detect as sd_mod
+
+        def _raise_exception(url):
+            raise RuntimeError("internal detail")
+
+        monkeypatch.setattr(sd_mod, "detect_stream_type", _raise_exception)
+
+        login(client)
+        resp = client.post(
+            "/admin/diagnostics/stream-detect",
+            json={"url": "http://example.com/live.m3u8"},
+        )
+        assert resp.status_code == 500
+        data = json.loads(resp.data)
+        assert data["error"] == "Stream detection failed. Check server logs for details."
+        assert "internal detail" not in resp.data.decode()
+        assert "Traceback" not in resp.data.decode()
+
+    def test_endpoint_hides_dns_exception_details(self, client, isolated_db, monkeypatch):
+        """DNS lookup errors should be returned as generic probe failures."""
+        import socket
+        import utils.stream_detect as sd_mod
+
+        def _raise_gaierror(*args, **kwargs):
+            raise socket.gaierror("temporary failure in name resolution")
+
+        monkeypatch.setattr(sd_mod.socket, "getaddrinfo", _raise_gaierror)
+
+        login(client)
+        resp = client.post(
+            "/admin/diagnostics/stream-detect",
+            json={"url": "http://example.com/live.m3u8"},
+        )
+        assert resp.status_code == 200
+        data = json.loads(resp.data)
+        assert data["fetch"]["error"] == "DNS resolution failed."
+        body = resp.data.decode()
+        assert "temporary failure in name resolution" not in body
+        assert "Traceback" not in body
+
     def test_stream_tab_visible_on_diagnostics_page(self, client, isolated_db):
         """The Stream Detect tab button appears in the diagnostics HTML."""
         login(client)

--- a/tests/test_epg_cache.py
+++ b/tests/test_epg_cache.py
@@ -1,0 +1,372 @@
+"""Tests for EPG disk cache helpers (_epg_cache_path, _load_epg_from_disk,
+_save_epg_to_disk) and the cache-aware load_tuner_data function."""
+import json
+import os
+import sys
+import tempfile
+import time
+
+import pytest
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from datetime import datetime, timezone
+from unittest.mock import patch, MagicMock
+
+import app as app_module
+from app import (
+    _epg_cache_path,
+    _serialize_epg,
+    _deserialize_epg,
+    _load_epg_from_disk,
+    _save_epg_to_disk,
+    load_tuner_data,
+    init_db,
+    init_tuners_db,
+    add_tuner,
+    add_combined_tuner,
+)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+@pytest.fixture()
+def isolated_env(tmp_path):
+    """Set up isolated databases for each test and clean up after.
+
+    EPG_CACHE_DIR isolation is provided by the autouse ``isolated_epg_cache``
+    fixture in conftest.py, which redirects ``app_module.EPG_CACHE_DIR`` to
+    ``tmp_path / 'epg_cache'`` before this fixture runs.  The yielded path is
+    that same directory so callers can assert on its contents without repeating
+    the path construction.
+    """
+    tmp_db = tmp_path / "users.db"
+    tmp_tuner_db = tmp_path / "tuners.db"
+
+    orig_db = app_module.DATABASE
+    orig_tuner_db = app_module.TUNER_DB
+
+    app_module.DATABASE = str(tmp_db)
+    app_module.TUNER_DB = str(tmp_tuner_db)
+
+    init_db()
+    init_tuners_db()
+
+    yield tmp_path / "epg_cache"  # matches what conftest.py sets for EPG_CACHE_DIR
+
+    app_module.DATABASE = orig_db
+    app_module.TUNER_DB = orig_tuner_db
+
+
+# ---------------------------------------------------------------------------
+# _epg_cache_path
+# ---------------------------------------------------------------------------
+
+class TestEpgCachePath:
+    def test_returns_json_file_in_cache_dir(self, isolated_env):
+        path = _epg_cache_path("MyTuner")
+        assert path.endswith(".json")
+        assert os.path.normpath(str(isolated_env)) in path
+
+    def test_sanitises_special_characters(self, isolated_env):
+        path = _epg_cache_path("Tuner With Spaces & Symbols!")
+        basename = os.path.basename(path)
+        assert " " not in basename
+        assert "&" not in basename
+        assert "!" not in basename
+
+    def test_raises_on_empty_name(self, isolated_env):
+        with pytest.raises(ValueError):
+            _epg_cache_path("")
+
+    def test_traversal_attempt_is_sanitised_not_raised(self, isolated_env):
+        """Path traversal characters are stripped during name sanitisation.
+
+        ``../../etc/passwd`` is converted to ``______etc_passwd`` so the
+        resulting file always stays inside EPG_CACHE_DIR.
+        """
+        path = _epg_cache_path("../../etc/passwd")
+        safe_dir = os.path.normpath(os.path.abspath(str(isolated_env)))
+        assert path.startswith(safe_dir + os.sep) or path == safe_dir
+
+
+# ---------------------------------------------------------------------------
+# _serialize_epg / _deserialize_epg round-trip
+# ---------------------------------------------------------------------------
+
+class TestEpgSerialisation:
+    EPG = {
+        "ch1": [
+            {
+                "title": "Morning News",
+                "desc": "Latest headlines",
+                "start": datetime(2024, 1, 1, 7, 0, 0, tzinfo=timezone.utc),
+                "stop": datetime(2024, 1, 1, 8, 0, 0, tzinfo=timezone.utc),
+                "icon": "https://example.com/img.png",
+                "categories": ["News"],
+                "colors": [],
+            }
+        ],
+        "ch2": [
+            {
+                "title": "No Guide Data Available",
+                "desc": "",
+                "start": None,
+                "stop": None,
+                "icon": "",
+                "categories": [],
+                "colors": [],
+            }
+        ],
+    }
+
+    def test_serialize_converts_datetimes_to_iso(self):
+        serialized = _serialize_epg(self.EPG)
+        prog = serialized["ch1"][0]
+        assert isinstance(prog["start"], str)
+        assert isinstance(prog["stop"], str)
+
+    def test_serialize_keeps_none_as_none(self):
+        serialized = _serialize_epg(self.EPG)
+        assert serialized["ch2"][0]["start"] is None
+        assert serialized["ch2"][0]["stop"] is None
+
+    def test_round_trip_preserves_datetimes(self):
+        serialized = _serialize_epg(self.EPG)
+        restored = _deserialize_epg(serialized)
+        prog = restored["ch1"][0]
+        assert isinstance(prog["start"], datetime)
+        assert prog["start"] == self.EPG["ch1"][0]["start"]
+        assert prog["stop"] == self.EPG["ch1"][0]["stop"]
+
+    def test_round_trip_preserves_none_dates(self):
+        serialized = _serialize_epg(self.EPG)
+        restored = _deserialize_epg(serialized)
+        assert restored["ch2"][0]["start"] is None
+        assert restored["ch2"][0]["stop"] is None
+
+    def test_round_trip_preserves_text_fields(self):
+        serialized = _serialize_epg(self.EPG)
+        restored = _deserialize_epg(serialized)
+        prog = restored["ch1"][0]
+        assert prog["title"] == "Morning News"
+        assert prog["desc"] == "Latest headlines"
+        assert prog["icon"] == "https://example.com/img.png"
+        assert prog["categories"] == ["News"]
+
+    def test_round_trip_json_compatible(self):
+        serialized = _serialize_epg(self.EPG)
+        dumped = json.dumps(serialized)
+        reloaded = json.loads(dumped)
+        restored = _deserialize_epg(reloaded)
+        assert restored["ch1"][0]["title"] == "Morning News"
+
+
+# ---------------------------------------------------------------------------
+# _save_epg_to_disk / _load_epg_from_disk
+# ---------------------------------------------------------------------------
+
+EPG_SAMPLE = {
+    "chan1": [
+        {
+            "title": "Test Show",
+            "desc": "A test",
+            "start": datetime(2024, 6, 1, 10, 0, tzinfo=timezone.utc),
+            "stop": datetime(2024, 6, 1, 11, 0, tzinfo=timezone.utc),
+            "icon": "",
+            "categories": [],
+            "colors": [],
+        }
+    ]
+}
+
+
+class TestSaveLoadEpg:
+    def test_save_creates_file(self, isolated_env):
+        _save_epg_to_disk("Tuner1", EPG_SAMPLE)
+        path = _epg_cache_path("Tuner1")
+        assert os.path.isfile(path)
+
+    def test_load_returns_epg_dict(self, isolated_env):
+        _save_epg_to_disk("Tuner1", EPG_SAMPLE)
+        loaded = _load_epg_from_disk("Tuner1")
+        assert loaded is not None
+        assert "chan1" in loaded
+        assert loaded["chan1"][0]["title"] == "Test Show"
+
+    def test_load_restores_datetimes(self, isolated_env):
+        _save_epg_to_disk("Tuner1", EPG_SAMPLE)
+        loaded = _load_epg_from_disk("Tuner1")
+        prog = loaded["chan1"][0]
+        assert isinstance(prog["start"], datetime)
+        assert prog["start"] == EPG_SAMPLE["chan1"][0]["start"]
+
+    def test_load_returns_none_when_missing(self, isolated_env):
+        result = _load_epg_from_disk("NonExistentTuner")
+        assert result is None
+
+    def test_load_returns_none_when_stale(self, isolated_env):
+        _save_epg_to_disk("Tuner1", EPG_SAMPLE)
+        path = _epg_cache_path("Tuner1")
+        # Back-date the file mtime by more than the TTL
+        old_mtime = time.time() - (app_module.EPG_DISK_CACHE_TTL + 3600)
+        os.utime(path, (old_mtime, old_mtime))
+        result = _load_epg_from_disk("Tuner1")
+        assert result is None
+
+    def test_load_ignores_ttl_when_max_age_none(self, isolated_env):
+        _save_epg_to_disk("Tuner1", EPG_SAMPLE)
+        path = _epg_cache_path("Tuner1")
+        old_mtime = time.time() - (app_module.EPG_DISK_CACHE_TTL + 3600)
+        os.utime(path, (old_mtime, old_mtime))
+        result = _load_epg_from_disk("Tuner1", max_age=None)
+        assert result is not None
+        assert "chan1" in result
+
+    def test_load_returns_none_on_corrupt_file(self, isolated_env):
+        os.makedirs(str(isolated_env), exist_ok=True)
+        path = _epg_cache_path("Tuner1")
+        with open(path, "w") as fh:
+            fh.write("not valid json{{{{")
+        result = _load_epg_from_disk("Tuner1")
+        assert result is None
+
+    def test_save_does_nothing_on_unsafe_name(self, isolated_env):
+        # Should not raise — just log and return
+        _save_epg_to_disk("", EPG_SAMPLE)
+        # The cache dir may not have been created at all when the name is
+        # rejected before os.makedirs() is reached.
+        files = list(isolated_env.iterdir()) if isolated_env.exists() else []
+        assert len(files) == 0
+
+
+# ---------------------------------------------------------------------------
+# load_tuner_data with disk cache
+# ---------------------------------------------------------------------------
+
+class TestLoadTunerDataCache:
+    """Verify that load_tuner_data uses the disk cache correctly."""
+
+    def test_standard_tuner_uses_fresh_cache(self, isolated_env):
+        """load_tuner_data should use the disk cache when it is fresh."""
+        add_tuner("T1", "https://example.com/g.xml", "https://example.com/p.m3u")
+        _save_epg_to_disk("T1", EPG_SAMPLE)
+
+        with patch("app.parse_m3u", return_value=[]) as mock_m3u, \
+             patch("app.parse_epg") as mock_epg:
+            channels, epg = load_tuner_data("T1")
+
+        mock_epg.assert_not_called()  # cache hit — no network fetch
+        assert "chan1" in epg
+
+    def test_standard_tuner_fetches_when_cache_stale(self, isolated_env):
+        """load_tuner_data should fetch from network when cache is stale."""
+        add_tuner("T1", "https://example.com/g.xml", "https://example.com/p.m3u")
+        _save_epg_to_disk("T1", EPG_SAMPLE)
+
+        # Back-date the cache to make it stale
+        path = _epg_cache_path("T1")
+        old_mtime = time.time() - (app_module.EPG_DISK_CACHE_TTL + 3600)
+        os.utime(path, (old_mtime, old_mtime))
+
+        fresh_epg = {"ch_fresh": [{"title": "Fresh", "desc": "", "start": None, "stop": None, "icon": "", "categories": [], "colors": []}]}
+        with patch("app.parse_m3u", return_value=[]), \
+             patch("app.parse_epg", return_value=fresh_epg):
+            channels, epg = load_tuner_data("T1")
+
+        assert "ch_fresh" in epg
+
+    def test_standard_tuner_force_refresh_bypasses_cache(self, isolated_env):
+        """force_refresh=True should skip the disk cache."""
+        add_tuner("T1", "https://example.com/g.xml", "https://example.com/p.m3u")
+        _save_epg_to_disk("T1", EPG_SAMPLE)
+
+        fresh_epg = {"forced": [{"title": "Forced", "desc": "", "start": None, "stop": None, "icon": "", "categories": [], "colors": []}]}
+        with patch("app.parse_m3u", return_value=[]), \
+             patch("app.parse_epg", return_value=fresh_epg):
+            channels, epg = load_tuner_data("T1", force_refresh=True)
+
+        assert "forced" in epg
+        assert "chan1" not in epg
+
+    def test_standard_tuner_saves_cache_after_fetch(self, isolated_env):
+        """After a successful network fetch, the EPG should be persisted to disk."""
+        add_tuner("T1", "https://example.com/g.xml", "https://example.com/p.m3u")
+        fresh_epg = {"ch_new": [{"title": "New", "desc": "", "start": None, "stop": None, "icon": "", "categories": [], "colors": []}]}
+
+        with patch("app.parse_m3u", return_value=[]), \
+             patch("app.parse_epg", return_value=fresh_epg):
+            load_tuner_data("T1")
+
+        path = _epg_cache_path("T1")
+        assert os.path.isfile(path)
+
+    def test_standard_tuner_stale_fallback_when_network_empty(self, isolated_env):
+        """When the network returns empty EPG, stale cache should be used as fallback."""
+        add_tuner("T1", "https://example.com/g.xml", "https://example.com/p.m3u")
+        _save_epg_to_disk("T1", EPG_SAMPLE)
+
+        # Make cache stale
+        path = _epg_cache_path("T1")
+        old_mtime = time.time() - (app_module.EPG_DISK_CACHE_TTL + 3600)
+        os.utime(path, (old_mtime, old_mtime))
+
+        with patch("app.parse_m3u", return_value=[]), \
+             patch("app.parse_epg", return_value={}):
+            channels, epg = load_tuner_data("T1")
+
+        # Should fall back to stale cache
+        assert "chan1" in epg
+
+    def test_combined_tuner_uses_fresh_cache(self, isolated_env):
+        """Combined load_tuner_data should use cache for the combined EPG."""
+        add_tuner("Src", "https://example.com/g.xml", "https://example.com/p.m3u")
+        add_combined_tuner("Combined", ["Src"])
+        _save_epg_to_disk("Combined", EPG_SAMPLE)
+
+        with patch("app.parse_m3u", return_value=[]) as mock_m3u, \
+             patch("app.parse_epg") as mock_epg:
+            channels, epg = load_tuner_data("Combined")
+
+        mock_epg.assert_not_called()
+        assert "chan1" in epg
+
+    def test_combined_tuner_force_refresh_bypasses_cache(self, isolated_env):
+        """Combined tuner with force_refresh=True should not use cache."""
+        add_tuner("Src", "https://example.com/g.xml", "https://example.com/p.m3u")
+        add_combined_tuner("Combined", ["Src"])
+        _save_epg_to_disk("Combined", EPG_SAMPLE)
+
+        fresh_epg = {"combined_fresh": [{"title": "CF", "desc": "", "start": None, "stop": None, "icon": "", "categories": [], "colors": []}]}
+        with patch("app.parse_m3u", return_value=[]), \
+             patch("app.parse_epg", return_value=fresh_epg):
+            channels, epg = load_tuner_data("Combined", force_refresh=True)
+
+        assert "combined_fresh" in epg
+        assert "chan1" not in epg
+
+    def test_combined_tuner_cached_epg_dedupes_duplicate_tvg_ids(self, isolated_env):
+        """Cache path should not return duplicate channel rows for the same tvg_id."""
+        add_tuner("SrcA", "https://example.com/a.xml", "https://example.com/a.m3u")
+        add_tuner("SrcB", "https://example.com/b.xml", "https://example.com/b.m3u")
+        add_combined_tuner("Combined", ["SrcA", "SrcB"])
+        _save_epg_to_disk("Combined", EPG_SAMPLE)
+
+        with patch("app.parse_m3u") as mock_m3u, patch("app.parse_epg") as mock_epg:
+            mock_m3u.side_effect = [
+                [{"name": "News A", "url": "http://a/news.m3u8", "logo": "", "tvg_id": "news"}],
+                [{"name": "News B", "url": "http://b/news.m3u8", "logo": "", "tvg_id": "news"}],
+            ]
+            channels, epg = load_tuner_data("Combined")
+
+        mock_epg.assert_not_called()
+        assert len(channels) == 1
+        assert channels[0]["tvg_id"] == "news"
+        assert "chan1" in epg
+
+    def test_load_nonexistent_tuner_returns_empty(self, isolated_env):
+        channels, epg = load_tuner_data("DoesNotExist")
+        assert channels == []
+        assert epg == {}

--- a/tests/test_guide_search_filter.py
+++ b/tests/test_guide_search_filter.py
@@ -117,3 +117,32 @@ class TestGuideSearchFilter:
         assert resp.status_code == 200
         assert b'data-categories="Movies | Drama"' in resp.data
         assert b'data-colors="Blue"' in resp.data
+
+    def test_guide_search_script_indexes_channel_numbers(self, client, monkeypatch):
+        now = datetime.now(timezone.utc)
+        monkeypatch.setattr(app_module, "cached_channels", [
+            {
+                "name": "Channel One",
+                "logo": "",
+                "url": "http://example.test/ch1.m3u8",
+                "tvg_id": "ch1",
+                "group": "Movies",
+                "tvg_chno": "101",
+            }
+        ])
+        monkeypatch.setattr(app_module, "cached_epg", {
+            "ch1": [{
+                "title": "Movie Night",
+                "desc": "Feature film",
+                "start": now - timedelta(minutes=10),
+                "stop": now + timedelta(minutes=50),
+                "icon": "",
+                "categories": ["Movies"],
+                "colors": ["Blue"],
+            }]
+        })
+
+        login(client)
+        resp = client.get("/guide")
+        assert resp.status_code == 200
+        assert b"chanEl ? (chanEl.dataset.chanNum || '') : ''" in resp.data

--- a/tests/test_install_scripts.py
+++ b/tests/test_install_scripts.py
@@ -1,0 +1,50 @@
+from pathlib import Path
+import re
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+def test_linux_installer_uses_product_specific_service_name():
+    script = (REPO_ROOT / "retroiptv_linux.sh").read_text()
+
+    assert 'SERVICE_NAME="retroiptvguide"' in script
+    assert 'LEGACY_SERVICE_NAME="iptv-server"' in script
+
+
+def test_linux_installer_only_cleans_legacy_service_when_owned_by_retroiptvguide():
+    script = (REPO_ROOT / "retroiptv_linux.sh").read_text()
+
+    assert "service_unit_belongs_to_retroiptvguide()" in script
+    assert 'grep -Fq "RetroIPTVGuide" "$unit_file"' in script
+    assert 'Leaving legacy $LEGACY_SERVICE_NAME service untouched because it is not owned by RetroIPTVGuide.' in script
+
+
+def test_linux_installer_legacy_execstart_regex_matches_supported_paths():
+    execstart_pattern = re.compile(
+        r"^\s*ExecStart=(/home/iptv/iptv-server|/opt/retroiptvguide)/venv/bin/(python|python3)(\s+-\S+)*\s+app\.py(\s+.*)?$"
+    )
+
+    assert execstart_pattern.match("ExecStart=/home/iptv/iptv-server/venv/bin/python app.py")
+    assert execstart_pattern.match("ExecStart=/home/iptv/iptv-server/venv/bin/python3 -u app.py")
+    assert execstart_pattern.match("  ExecStart=/opt/retroiptvguide/venv/bin/python3 app.py --port 5000")
+    assert not execstart_pattern.match("ExecStart=/srv/otherapp/venv/bin/python3 app.py")
+
+
+def test_linux_installer_workingdirectory_regex_matches_supported_paths():
+    working_directory_pattern = re.compile(
+        r"^\s*WorkingDirectory=(/home/iptv/iptv-server|/opt/retroiptvguide)\s*$"
+    )
+
+    assert working_directory_pattern.match("WorkingDirectory=/home/iptv/iptv-server")
+    assert working_directory_pattern.match("  WorkingDirectory=/opt/retroiptvguide  ")
+    assert not working_directory_pattern.match("WorkingDirectory=/srv/otherapp")
+
+
+def test_linux_updater_rewrites_current_service_before_legacy_cleanup():
+    script = (REPO_ROOT / "retroiptv_linux.sh").read_text()
+
+    update_section = script.split("update_linux(){", 1)[1].split("uninstall_linux(){", 1)[0]
+
+    assert "write_systemd_service" in update_section
+    assert update_section.index("write_systemd_service") < update_section.index("cleanup_legacy_service_if_owned")

--- a/tests/test_mini_guide.py
+++ b/tests/test_mini_guide.py
@@ -1,4 +1,4 @@
-"""Tests for the mini guide overlay on the guide page."""
+"""Tests for the mini guide layout on the guide page."""
 import os
 import sys
 
@@ -54,29 +54,12 @@ def mini_guide_js():
 
 
 class TestMiniGuideMarkup:
-    def test_guide_renders_mini_guide_button(self, guide_html):
-        assert 'id="miniGuideBtn"' in guide_html
-        assert 'aria-label="Toggle mini guide"' in guide_html
-        assert 'title="Mini Guide"' in guide_html
+    def test_guide_does_not_render_mini_guide_overlay_button(self, guide_html):
+        assert 'id="miniGuideBtn"' not in guide_html
 
-    def test_guide_renders_mini_guide_panel(self, guide_html):
-        assert 'id="miniGuide"' in guide_html
-        assert 'class="mini-guide"' in guide_html
-        assert 'id="mgChannelList"' in guide_html
-
-    def test_guide_sets_dialog_aria_attributes(self, guide_html):
-        assert 'role="dialog"' in guide_html
-        assert 'aria-modal="false"' in guide_html
-        assert 'aria-label="Mini guide"' in guide_html
-        assert 'aria-hidden="true"' in guide_html
-
-    def test_guide_sets_channel_list_aria_attributes(self, guide_html):
-        assert 'role="listbox"' in guide_html
-        assert 'aria-label="Channels near current channel"' in guide_html
-
-    def test_guide_renders_close_button(self, guide_html):
-        assert 'id="miniGuideClose"' in guide_html
-        assert 'aria-label="Close mini guide"' in guide_html
+    def test_guide_does_not_render_mini_guide_overlay_panel(self, guide_html):
+        assert 'id="miniGuide"' not in guide_html
+        assert 'id="mgChannelList"' not in guide_html
 
     def test_guide_loads_mini_guide_script(self, guide_html):
         assert "js/mini-guide.js" in guide_html
@@ -93,10 +76,10 @@ class TestMiniGuideMarkup:
 
 
 class TestMiniGuideScript:
-    def test_script_exposes_public_api(self, mini_guide_js):
-        assert "window.openMiniGuide = openMiniGuide;" in mini_guide_js
-        assert "window.closeMiniGuide = closeMiniGuide;" in mini_guide_js
-        assert "window.toggleMiniGuide = toggleMiniGuide;" in mini_guide_js
+    def test_script_does_not_expose_overlay_api(self, mini_guide_js):
+        assert "window.openMiniGuide" not in mini_guide_js
+        assert "window.closeMiniGuide" not in mini_guide_js
+        assert "window.toggleMiniGuide" not in mini_guide_js
 
     def test_script_uses_dom_source_for_channels(self, mini_guide_js):
         assert "document.querySelectorAll('.guide-row[data-cid]')" in mini_guide_js
@@ -104,24 +87,10 @@ class TestMiniGuideScript:
         assert 'fetch("/api/channels"' not in mini_guide_js
         assert "fetch('/api/channels'" not in mini_guide_js
 
-    def test_script_limits_overlay_to_seven_rows(self, mini_guide_js):
-        assert "MINI_GUIDE_ROW_COUNT = 7" in mini_guide_js
-        assert "selectedWindow()" in mini_guide_js
-
-    def test_script_sets_eight_second_autodismiss(self, mini_guide_js):
-        assert "MINI_GUIDE_AUTODISMISS_MS = 8000" in mini_guide_js
-        assert "setTimeout(closeMiniGuide, MINI_GUIDE_AUTODISMISS_MS)" in mini_guide_js
-
-    def test_script_defines_keyboard_shortcuts(self, mini_guide_js):
-        assert "MINI_GUIDE_TOGGLE_KEY = 'g'" in mini_guide_js
-        assert "event.key === 'ArrowUp'" in mini_guide_js
-        assert "event.key === 'ArrowDown'" in mini_guide_js
-        assert "event.key === 'Enter'" in mini_guide_js
-        assert "event.key === 'Escape'" in mini_guide_js
-
-    def test_script_tunes_selected_channel_with_existing_player(self, mini_guide_js):
-        assert "typeof window.playChannel !== 'function'" in mini_guide_js
-        assert "window.playChannel(channel.url, channel.cid, channel.name)" in mini_guide_js
+    def test_script_does_not_define_overlay_keyboard_shortcuts(self, mini_guide_js):
+        assert "MINI_GUIDE_TOGGLE_KEY" not in mini_guide_js
+        assert "openMiniGuide" not in mini_guide_js
+        assert "closeMiniGuide" not in mini_guide_js
 
     def test_script_exposes_layout_api_and_pref_key(self, mini_guide_js):
         assert "guide_layout" in mini_guide_js
@@ -131,14 +100,12 @@ class TestMiniGuideScript:
 
 
 class TestMiniGuideStyles:
-    def test_styles_include_slide_in_panel_and_open_state(self, guide_html):
-        assert ".mini-guide {" in guide_html
-        assert "transform: translate(-110%, -50%);" in guide_html
-        assert ".mini-guide.is-open {" in guide_html
-        assert "transform: translate(0, -50%);" in guide_html
+    def test_styles_do_not_include_slide_in_overlay_panel(self, guide_html):
+        assert "transform: translate(-110%, -50%);" not in guide_html
+        assert ".mini-guide.is-open {" not in guide_html
 
-    def test_styles_include_selected_row_and_progress_bar(self, guide_html):
-        assert ".mini-guide-row.is-selected" in guide_html
+    def test_styles_include_row_hover_and_progress_bar(self, guide_html):
+        assert ".mini-guide-row:hover {" in guide_html
         assert ".mg-progress-wrap" in guide_html
         assert ".mg-progress-bar" in guide_html
 

--- a/tests/test_traffic_demo.py
+++ b/tests/test_traffic_demo.py
@@ -347,7 +347,7 @@ class TestApiTrafficEndpoint:
             assert k in data['summary']
 
     def test_no_cities_selected_returns_no_cities_flag(self, client):
-        login(client)
+        login(client, "admin", "adminpass")
         client.post('/api/traffic/demo/disable_all')
         data = client.get('/api/traffic').get_json()
         assert data['no_cities'] is True
@@ -379,7 +379,7 @@ class TestApiTrafficDemoCities:
         assert len(data['cities']) == len(_TRAFFIC_DEMO_CITIES_SEED)
 
     def test_city_update_endpoint(self, client):
-        login(client)
+        login(client, "admin", "adminpass")
         cities = client.get('/api/traffic/demo/cities').get_json()['cities']
         city_id = cities[0]['id']
         resp = client.post(f'/api/traffic/demo/cities/{city_id}',
@@ -393,12 +393,22 @@ class TestApiTrafficDemoCities:
         assert updated['enabled'] is False
         assert updated['weight'] == 2
 
+    def test_city_update_requires_admin(self, client):
+        login(client)
+        cities = client.get('/api/traffic/demo/cities').get_json()['cities']
+        assert cities, "Expected seeded traffic demo cities for update test"
+        city_id = cities[0]['id']
+        resp = client.post(f'/api/traffic/demo/cities/{city_id}',
+                           data=json.dumps({'enabled': False, 'weight': 2}),
+                           content_type='application/json')
+        assert resp.status_code == 403
+
 
 # ─── /api/traffic/demo/enable_all and /disable_all ───────────────────────────
 
 class TestApiTrafficDemoBulkActions:
     def test_enable_all(self, client):
-        login(client)
+        login(client, "admin", "adminpass")
         client.post('/api/traffic/demo/disable_all')
         resp = client.post('/api/traffic/demo/enable_all')
         assert resp.get_json()['ok'] is True
@@ -406,18 +416,25 @@ class TestApiTrafficDemoBulkActions:
         assert all(c['enabled'] for c in cities)
 
     def test_disable_all(self, client):
-        login(client)
+        login(client, "admin", "adminpass")
         resp = client.post('/api/traffic/demo/disable_all')
         assert resp.get_json()['ok'] is True
         cities = client.get('/api/traffic/demo/cities').get_json()['cities']
         assert all(not c['enabled'] for c in cities)
+
+    def test_bulk_actions_require_admin(self, client):
+        login(client)
+        enable_resp = client.post('/api/traffic/demo/enable_all')
+        disable_resp = client.post('/api/traffic/demo/disable_all')
+        assert enable_resp.status_code == 403
+        assert disable_resp.status_code == 403
 
 
 # ─── /api/traffic/demo/pick_random ───────────────────────────────────────────
 
 class TestApiTrafficDemoPickRandom:
     def test_pick_random_returns_ok(self, client):
-        login(client)
+        login(client, "admin", "adminpass")
         resp = client.post('/api/traffic/demo/pick_random',
                            data=json.dumps({'pack_size': 5}),
                            content_type='application/json')
@@ -427,12 +444,19 @@ class TestApiTrafficDemoPickRandom:
         assert len(data['cities']) == 5
 
     def test_pick_random_uses_default_pack_size(self, client):
-        login(client)
+        login(client, "admin", "adminpass")
         resp = client.post('/api/traffic/demo/pick_random',
                            data='{}', content_type='application/json')
         data = resp.get_json()
         assert data['ok'] is True
         assert len(data['cities']) == 10  # default pack_size
+
+    def test_non_admin_forbidden(self, client):
+        login(client)
+        resp = client.post('/api/traffic/demo/pick_random',
+                           data=json.dumps({'pack_size': 5}),
+                           content_type='application/json')
+        assert resp.status_code == 403
 
 
 # ─── add_traffic_demo_city / delete_traffic_demo_city helpers ─────────────────

--- a/tests/test_tuner_cache_refresh.py
+++ b/tests/test_tuner_cache_refresh.py
@@ -1,0 +1,84 @@
+import os
+import sys
+from unittest.mock import patch
+
+import pytest
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+import app as app_module
+from app import app, init_db, init_tuners_db, add_user, add_tuner, get_setting, set_current_tuner
+
+
+@pytest.fixture(autouse=True)
+def isolated_env(tmp_path, monkeypatch):
+    users_db = str(tmp_path / "users_test.db")
+    tuners_db = str(tmp_path / "tuners_test.db")
+    monkeypatch.setattr(app_module, "DATABASE", users_db)
+    monkeypatch.setattr(app_module, "TUNER_DB", tuners_db)
+    monkeypatch.setattr(app_module, "cached_channels", [])
+    monkeypatch.setattr(app_module, "cached_epg", {})
+    init_db()
+    init_tuners_db()
+    add_user("admin", "adminpass")
+    add_user("testuser", "testpass")
+    yield
+
+
+@pytest.fixture()
+def client(isolated_env):
+    app.config["TESTING"] = True
+    with app.test_client() as c:
+        yield c
+
+
+def login(client, username="admin", pw="adminpass"):
+    return client.post(
+        "/login",
+        data={"username": username, "password": pw},
+        follow_redirects=True,
+    )
+
+
+class TestRefreshCurrentTuner:
+    def test_refreshing_non_active_tuner_keeps_active_memory_cache(self):
+        add_tuner("Active", "https://example.com/a.xml", "https://example.com/a.m3u")
+        add_tuner("Other", "https://example.com/b.xml", "https://example.com/b.m3u")
+        set_current_tuner("Active")
+        app_module.cached_channels = [{"name": "Active Channel"}]
+        app_module.cached_epg = {"active": [{"title": "Active Show"}]}
+
+        with patch(
+            "app.load_tuner_data",
+            return_value=([{"name": "Other Channel"}], {"other": [{"title": "Other Show"}]}),
+        ) as mock_load, patch("app.apply_epg_fallback", side_effect=lambda channels, epg: epg):
+            assert app_module.refresh_current_tuner("Other") is True
+
+        mock_load.assert_called_once_with("Other", force_refresh=True)
+        assert app_module.cached_channels == [{"name": "Active Channel"}]
+        assert app_module.cached_epg == {"active": [{"title": "Active Show"}]}
+        assert get_setting("last_auto_refresh:Other", "").startswith("success|")
+
+
+class TestAutoRefreshTriggerApi:
+    def test_admin_can_refresh_selected_tuner(self, client):
+        add_tuner("Refresh Source 1", "https://example.com/1.xml", "https://example.com/1.m3u")
+        add_tuner("Refresh Source 2", "https://example.com/2.xml", "https://example.com/2.m3u")
+        set_current_tuner("Refresh Source 1")
+        login(client, "admin", "adminpass")
+
+        with patch("app.refresh_current_tuner", return_value=True) as mock_refresh:
+            resp = client.post("/api/auto_refresh/trigger", json={"tuner": "Refresh Source 2"})
+
+        assert resp.status_code == 200
+        assert resp.get_json() == {"ok": True, "tuner": "Refresh Source 2"}
+        mock_refresh.assert_called_once_with("Refresh Source 2")
+
+    def test_non_admin_cannot_refresh_tuner(self, client):
+        add_tuner("Locked Refresh Tuner", "https://example.com/1.xml", "https://example.com/1.m3u")
+        login(client, "testuser", "testpass")
+
+        resp = client.post("/api/auto_refresh/trigger", json={"tuner": "Locked Refresh Tuner"})
+
+        assert resp.status_code == 403
+        assert resp.get_json()["error"] == "Unauthorized"

--- a/tests/test_user_prefs.py
+++ b/tests/test_user_prefs.py
@@ -8,7 +8,7 @@ import pytest
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
 import app as app_module
-from app import app, init_db, init_tuners_db, get_user_prefs, save_user_prefs, _DEFAULT_PREFS
+from app import app, init_db, init_tuners_db, get_user_prefs, save_user_prefs, _DEFAULT_PREFS, add_user
 
 
 # ─── Fixtures ────────────────────────────────────────────────────────────────
@@ -306,6 +306,34 @@ class TestManageUsersSetPrefs:
         # Non-admins are redirected away from manage_users; prefs remain unchanged
         assert get_user_prefs("testuser")["auto_load_channel"] is None
 
+    def test_non_admin_cannot_open_manage_users(self, client):
+        login(client, "testuser", "testpass")
+        resp = client.get("/manage_users", follow_redirects=False)
+        assert resp.status_code == 302
+        assert resp.headers.get("Location", "").endswith("/guide")
+
+    def test_admin_tv_user_agent_cannot_open_manage_users(self, client):
+        login(client, "admin", "adminpass")
+        resp = client.get(
+            "/manage_users",
+            headers={"User-Agent": "Mozilla/5.0 (Linux; Android TV)"},
+            follow_redirects=False,
+        )
+        assert resp.status_code == 302
+        assert resp.headers.get("Location", "").endswith("/guide")
+
+    def test_admin_can_assign_tuner_for_user(self, client):
+        login(client, "admin", "adminpass")
+        resp = client.post("/manage_users", data={
+            "action": "assign_tuner",
+            "username": "testuser",
+            "tuner_name": "Tuner 2",
+        }, follow_redirects=True)
+        assert resp.status_code == 200
+        resp = client.get("/manage_users")
+        assert resp.status_code == 200
+        assert b'data-current-tuner="Tuner 2"' in resp.data
+
     def test_auto_load_channel_name_from_form_field(self, client):
         """Channel name must come from the submitted auto_load_channel_name form
         field, not from a server-side lookup against cached_channels."""
@@ -433,6 +461,46 @@ class TestManageUsersSetPrefs:
         prefs = get_user_prefs("testuser")
         assert prefs["auto_load_channel"] is not None
         assert prefs["auto_load_channel"]["id"] == "keep-ch"
+
+    def test_api_channels_uses_assigned_tuner_per_user(self, client, monkeypatch):
+        """Different users with different assigned tuners should receive different channel lists."""
+        add_user("otheruser", "otherpass")
+
+        login(client, "admin", "adminpass")
+        client.post("/manage_users", data={
+            "action": "assign_tuner",
+            "username": "testuser",
+            "tuner_name": "Tuner 1",
+        }, follow_redirects=True)
+        client.post("/manage_users", data={
+            "action": "assign_tuner",
+            "username": "otheruser",
+            "tuner_name": "Tuner 2",
+        }, follow_redirects=True)
+
+        t1_channels = [{"tvg_id": "t1.ch", "name": "Tuner 1 Channel", "url": "http://t1/stream"}]
+        t2_channels = [{"tvg_id": "t2.ch", "name": "Tuner 2 Channel", "url": "http://t2/stream"}]
+        monkeypatch.setattr(app_module, "cached_channels", t1_channels)
+        monkeypatch.setattr(app_module, "cached_epg", {})
+        monkeypatch.setattr(
+            app_module,
+            "load_tuner_data",
+            lambda tuner_name, force_refresh=False: (t2_channels, {}) if tuner_name == "Tuner 2" else (t1_channels, {}),
+        )
+
+        client.get("/logout")
+        login(client, "testuser", "testpass")
+        data_testuser = client.get("/api/channels").get_json()
+        names_testuser = [ch["name"] for ch in data_testuser["channels"]]
+        assert "Tuner 1 Channel" in names_testuser
+        assert "Tuner 2 Channel" not in names_testuser
+
+        client.get("/logout")
+        login(client, "otheruser", "otherpass")
+        data_other = client.get("/api/channels").get_json()
+        names_other = [ch["name"] for ch in data_other["channels"]]
+        assert "Tuner 2 Channel" in names_other
+        assert "Tuner 1 Channel" not in names_other
 
     def test_manage_users_response_has_no_store_header(self, client):
         """GET /manage_users must return Cache-Control: no-store so browsers

--- a/tests/test_user_prefs_channel_numbers.py
+++ b/tests/test_user_prefs_channel_numbers.py
@@ -9,12 +9,20 @@ sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 import app as app_module
 
 
-def _simulate_user_prefs_channel_numbers(channels, body_classes=None, add_channel=None):
+def _simulate_user_prefs_channel_numbers(
+    channels,
+    body_classes=None,
+    add_channel=None,
+    prefs=None,
+    toggle_show_hidden=False,
+):
     js_path = Path(app_module.app.static_folder) / "js" / "user-prefs.js"
     payload = json.dumps({
         "channels": channels,
         "body_classes": body_classes or [],
         "add_channel": add_channel,
+        "prefs": prefs,
+        "toggle_show_hidden": toggle_show_hidden,
         "script_path": str(js_path),
     })
     node_script = r"""
@@ -34,7 +42,8 @@ function makeClassList(initial = []) {
       if (s.has(item)) { s.delete(item); return false; }
       s.add(item); return true;
     },
-    contains: (item) => s.has(item)
+    contains: (item) => s.has(item),
+    toArray: () => Array.from(s)
   };
 }
 
@@ -53,10 +62,14 @@ function makeUserNumNode(text) {
 
 function makeChannel(cid, hasBuiltIn) {
   const el = {
+    nodeType: 1,
     dataset: { cid },
     _children: [],
+    _listeners: {},
     firstChild: null,
-    addEventListener: () => {},
+    addEventListener: (event, cb) => {
+      el._listeners[event] = cb;
+    },
     closest: () => null,
     querySelector: (sel) => {
       if (sel === '.channel-number') return hasBuiltIn ? { className: 'channel-number' } : null;
@@ -72,8 +85,22 @@ function makeChannel(cid, hasBuiltIn) {
   return el;
 }
 
+function makeRow(cid) {
+  const row = {
+    nodeType: 1,
+    dataset: { cid },
+    classList: makeClassList(),
+    matches: (sel) => sel === '.guide-row[data-cid]',
+    querySelector: (sel) => {
+      if (sel === '.chan-name') return chanEls.find(ch => ch.dataset.cid === cid) || null;
+      return null;
+    }
+  };
+  return row;
+}
+
 const chanEls = input.channels.map(ch => makeChannel(ch.cid, !!ch.built_in));
-const rows = input.channels.map(ch => ({ dataset: { cid: ch.cid }, classList: makeClassList() }));
+const rows = input.channels.map(ch => makeRow(ch.cid));
 const guideOuter = {};
 let domReadyCb = null;
 let mutationCb = null;
@@ -83,12 +110,18 @@ const document = {
   body: { classList: makeClassList(input.body_classes || []) },
   querySelectorAll: (sel) => {
     if (sel === '.guide-row[data-cid]') return rows;
+    if (sel === '.guide-row.chan-hidden') return rows.filter(r => r.classList.contains('chan-hidden'));
     if (sel === '.guide-row[data-cid] .chan-name') return chanEls;
     if (sel === '.chan-name') return chanEls;
     if (sel === '.chan-name .user-channel-number') {
       return chanEls.flatMap(ch => ch._children.filter(n => n.className === 'user-channel-number'));
     }
     return [];
+  },
+  querySelector: (sel) => {
+    const rowMatch = sel.match(/^\.guide-row\[data-cid="(.+)"\]$/);
+    if (rowMatch) return rows.find(r => r.dataset.cid === rowMatch[1]) || null;
+    return null;
   },
   getElementById: (id) => (id === 'guideOuter' ? guideOuter : null),
   addEventListener: (event, cb) => {
@@ -101,7 +134,7 @@ const document = {
 };
 
 const windowObj = {
-  __initialUserPrefs: { channel_numbers_enabled: true },
+  __initialUserPrefs: Object.assign({ channel_numbers_enabled: true }, input.prefs || {}),
   addEventListener: () => {},
   console,
 };
@@ -114,7 +147,7 @@ const context = {
   document,
   window: windowObj,
   MutationObserver,
-  fetch: async () => ({ ok: true, json: async () => ({ prefs: { channel_numbers_enabled: true } }) }),
+  fetch: async () => ({ ok: true, json: async () => ({ prefs: Object.assign({ channel_numbers_enabled: true }, input.prefs || {}) }) }),
   alert: () => {},
   CSS: { escape: (s) => s },
   setTimeout: (fn) => { fn(); return 1; },
@@ -124,6 +157,9 @@ const context = {
 
 vm.runInNewContext(source, context, { filename: 'user-prefs.js' });
 if (domReadyCb) domReadyCb();
+if (input.toggle_show_hidden && windowObj.__userPrefs && typeof windowObj.__userPrefs.toggleShowHidden === 'function') {
+  windowObj.__userPrefs.toggleShowHidden();
+}
 
 function labels() {
   return chanEls.map(ch => {
@@ -132,13 +168,35 @@ function labels() {
   });
 }
 
-const out = { initial: labels() };
+function rowClasses() {
+  const out = {};
+  rows.forEach(row => {
+    out[row.dataset.cid] = row.classList.toArray();
+  });
+  return out;
+}
+
+function contextMenuBindings() {
+  const out = {};
+  chanEls.forEach(ch => {
+    out[ch.dataset.cid] = !!ch._listeners.contextmenu;
+  });
+  return out;
+}
+
+const out = {
+  initial: labels(),
+  initialRowClasses: rowClasses(),
+  initialContextMenuBindings: contextMenuBindings()
+};
 
 if (input.add_channel) {
   chanEls.push(makeChannel(input.add_channel.cid, !!input.add_channel.built_in));
-  rows.push({ dataset: { cid: input.add_channel.cid }, classList: makeClassList() });
-  if (mutationCb) mutationCb([{ type: 'childList', addedNodes: [1], removedNodes: [] }]);
+  rows.push(makeRow(input.add_channel.cid));
+  if (mutationCb) mutationCb([{ type: 'childList', addedNodes: [rows[rows.length - 1]], removedNodes: [] }]);
   out.afterMutation = labels();
+  out.afterMutationRowClasses = rowClasses();
+  out.afterMutationContextMenuBindings = contextMenuBindings();
 }
 
 process.stdout.write(JSON.stringify(out));
@@ -174,3 +232,26 @@ def test_user_channel_numbers_not_injected_for_builtin_number_theme():
         body_classes=["tvguide1990"],
     )
     assert result["initial"] == ["", ""]
+
+
+def test_user_prefs_reapply_row_state_and_context_menu_after_mutation():
+    result = _simulate_user_prefs_channel_numbers(
+        channels=[
+            {"cid": "existing.favorite"},
+        ],
+        add_channel={"cid": "new.favorite"},
+        prefs={
+            "channel_numbers_enabled": False,
+            "favorite_channels": ["existing.favorite", "new.favorite"],
+            "hidden_channels": ["new.favorite"],
+            "auto_load_channel": {"id": "new.favorite", "name": "New Favorite"},
+        },
+        toggle_show_hidden=True,
+    )
+
+    new_row_classes = result["afterMutationRowClasses"]["new.favorite"]
+    assert "chan-favorite" in new_row_classes
+    assert "chan-hidden" in new_row_classes
+    assert "chan-hidden-visible" in new_row_classes
+    assert "chan-autoload" in new_row_classes
+    assert result["afterMutationContextMenuBindings"]["new.favorite"] is True

--- a/tests/test_weather.py
+++ b/tests/test_weather.py
@@ -673,14 +673,14 @@ class TestBgOverrideEndpoint:
     """Tests for the /api/weather/bg_override AJAX endpoint."""
 
     def test_get_returns_empty_by_default(self, client):
-        login(client)
+        login(client, "admin", "adminpass")
         r = client.get('/api/weather/bg_override')
         assert r.status_code == 200
         data = r.get_json()
         assert data['condition'] == ''
 
     def test_post_sets_condition(self, client):
-        login(client)
+        login(client, "admin", "adminpass")
         r = client.post('/api/weather/bg_override',
                         json={'condition': 'thunderstorm'},
                         content_type='application/json')
@@ -690,7 +690,7 @@ class TestBgOverrideEndpoint:
         assert data['condition'] == 'thunderstorm'
 
     def test_post_persists_condition(self, client):
-        login(client)
+        login(client, "admin", "adminpass")
         client.post('/api/weather/bg_override',
                     json={'condition': 'rain'},
                     content_type='application/json')
@@ -698,7 +698,7 @@ class TestBgOverrideEndpoint:
         assert r.get_json()['condition'] == 'rain'
 
     def test_post_auto_clears_override(self, client):
-        login(client)
+        login(client, "admin", "adminpass")
         client.post('/api/weather/bg_override',
                     json={'condition': 'snow'},
                     content_type='application/json')
@@ -709,7 +709,7 @@ class TestBgOverrideEndpoint:
         assert r.get_json()['condition'] == ''
 
     def test_post_empty_string_clears_override(self, client):
-        login(client)
+        login(client, "admin", "adminpass")
         client.post('/api/weather/bg_override',
                     json={'condition': 'sunny'},
                     content_type='application/json')
@@ -720,7 +720,7 @@ class TestBgOverrideEndpoint:
         assert r.get_json()['condition'] == ''
 
     def test_post_invalid_condition_returns_400(self, client):
-        login(client)
+        login(client, "admin", "adminpass")
         r = client.post('/api/weather/bg_override',
                         json={'condition': 'tornado'},
                         content_type='application/json')
@@ -728,7 +728,7 @@ class TestBgOverrideEndpoint:
         assert r.get_json()['ok'] is False
 
     def test_delete_clears_override(self, client):
-        login(client)
+        login(client, "admin", "adminpass")
         client.post('/api/weather/bg_override',
                     json={'condition': 'foggy'},
                     content_type='application/json')
@@ -750,10 +750,21 @@ class TestBgOverrideEndpoint:
 
     def test_api_weather_reflects_override(self, client):
         """After setting override, /api/weather returns that bg_condition."""
-        login(client)
+        login(client, "admin", "adminpass")
         client.post('/api/weather/bg_override',
                     json={'condition': 'windy'},
                     content_type='application/json')
         data = client.get('/api/weather').get_json()
         assert data['bg_condition'] == 'windy'
         assert data['bg_condition_override'] == 'windy'
+
+    def test_non_admin_forbidden(self, client):
+        login(client)
+        get_resp = client.get('/api/weather/bg_override')
+        post_resp = client.post('/api/weather/bg_override',
+                                json={'condition': 'snow'},
+                                content_type='application/json')
+        delete_resp = client.delete('/api/weather/bg_override')
+        assert get_resp.status_code == 403
+        assert post_resp.status_code == 403
+        assert delete_resp.status_code == 403

--- a/tests/test_whats_on_now.py
+++ b/tests/test_whats_on_now.py
@@ -189,6 +189,14 @@ class TestWhatsOnNowPage:
         resp = client.get("/whats-on-now")
         assert b"/api/whats_on_now" in resp.data
 
+    def test_page_does_not_load_guide_mobile_scroll_fix_css(self, client, monkeypatch):
+        """What's On Now should not load guide-only mobile scroll locking CSS."""
+        monkeypatch.setattr(app_module, "cached_channels", _make_channels())
+        monkeypatch.setattr(app_module, "cached_epg",      _make_epg())
+        login(client)
+        resp = client.get("/whats-on-now")
+        assert b"css/mobile-scroll-fix.css" not in resp.data
+
     def test_page_stores_pending_play_in_session_storage(self, client, monkeypatch):
         """Clicking a card stores wonPendingPlay in sessionStorage before navigating."""
         monkeypatch.setattr(app_module, "cached_channels", _make_channels())
@@ -209,3 +217,4 @@ class TestWhatsOnNowPage:
         text = resp.data.decode()
         assert "wonPendingPlay" in text
         assert "sessionStorage.getItem" in text
+

--- a/utils/app_config_diag.py
+++ b/utils/app_config_diag.py
@@ -655,10 +655,10 @@ def _probe_service(svc_id: str, name: str, url: str, timeout: int = 8) -> Dict[s
         "resolved_ip": None,
     }
 
-    # Strip query string and fragment for logging to avoid exposing API keys or tokens
-    # that may appear as query parameters (e.g. ?api_key=…).
+    # Strip query string, fragment, and embedded credentials for logging to avoid
+    # exposing API keys, tokens, or passwords (e.g. ?api_key=… or user:pass@host).
     parsed = urlparse(url)
-    _log_url = parsed._replace(query="", fragment="").geturl()
+    _log_url = _sanitize_url_for_log(parsed._replace(query="", fragment="").geturl())
     hostname = parsed.hostname
 
     try:
@@ -666,8 +666,8 @@ def _probe_service(svc_id: str, name: str, url: str, timeout: int = 8) -> Dict[s
             try:
                 result["resolved_ip"] = socket.getaddrinfo(hostname, None)[0][4][0]
             except socket.gaierror as dns_err:
-                # hostname is the bare domain name (e.g. api.nasa.gov) — no query parameters
-                logger.debug("DNS resolution failed for '%s': %s", hostname, dns_err)
+                # _log_url has credentials and query params stripped (safe to log)
+                logger.debug("DNS resolution failed for '%s': %s", _log_url, dns_err)
                 result["error"] = "DNS resolution failed. Check application logs for details."
                 return result
 

--- a/utils/stream_detect.py
+++ b/utils/stream_detect.py
@@ -238,6 +238,7 @@ def detect_stream_type(url: str) -> Dict[str, Any]:
     result["fetch"] = fetch
 
     if not fetch["ok"]:
+        fetch.pop("raw_bytes", None)
         result["confidence"] = "none"
         result["description"] = f"HTTP probe failed: {fetch.get('error', 'unknown error')}."
         result["tips"].append("Verify the URL is reachable from the server, not just from your browser.")
@@ -1002,8 +1003,9 @@ def _fetch_partial(url: str, timeout: int = _TIMEOUT, resolved_ip: Optional[str]
                 if not addr_info:
                     raise socket.gaierror(f"No addresses returned for '{_original_hostname}'")
                 _effective_ip = addr_info[0][4][0]
-            except (socket.gaierror, OSError, IndexError) as _gai_err:
-                result["error"] = f"DNS resolution failed: {_gai_err}"
+            except (socket.gaierror, OSError, IndexError) as _dns_error:
+                logger.debug("DNS resolution failed during stream fetch for %s: %s", url, _dns_error)
+                result["error"] = "DNS resolution failed."
                 result["response_time_ms"] = int((time.monotonic() - t0) * 1000)
                 return result
 


### PR DESCRIPTION
## v4.9.8 - 2026-07-10

### Added

* Added **EPG disk caching**.

  * Added persistent on-disk EPG JSON cache under `DATA_DIR/epg_cache`.
  * Added `EPG_CACHE_DIR` and `EPG_DISK_CACHE_TTL`.
  * EPG cache defaults to a 24-hour TTL.
  * Added safe cache filename generation for tuner names.
  * Added EPG serialization/deserialization helpers for storing guide data with datetime values.
  * Added stale-cache fallback when XMLTV loading returns no guide data.
  * Added EPG caching support for both standard tuners and combined tuners.
  * Added duplicate channel filtering by `tvg_id` when loading tuner data.

* Added **per-user assigned tuner handling**.

  * Added helper logic to determine the effective tuner for the current user.
  * Guide, API channel list, Channel Health, Current Program, and What’s On Now now use the current user’s effective tuner instead of always using the global active tuner.
  * Assigned tuners fall back to the current global tuner if the assigned tuner no longer exists.

* Added **manual JSON cache refresh for selected tuners**.

  * Added `/api/auto_refresh/trigger` endpoint.
  * Admins can now force-refresh the selected tuner’s guide/JSON cache.
  * Refreshing a non-active tuner updates that tuner’s cache without replacing the active in-memory guide.
  * Updated the Change Tuner page button from **Run Sync Now** to **Refresh JSON Cache**.
  * The refresh action now sends the selected tuner name and reports which tuner was refreshed.

* Added **mobile Program Info folding**.

  * Added a mobile-only **Hide Info / Program Info** toggle for the guide summary panel.
  * The summary panel can collapse to free vertical space for the video and guide grid on small screens.
  * Added one-minute auto-collapse while video is playing on mobile.
  * The summary panel re-expands on channel changes.
  * Added `static/js/mobile-summary-fold.js`.

* Added **RetroStation MC theme**.

  * Added `retrostation-mc` theme styling.
  * Added RetroStation MC to the desktop and mobile theme menus.

* Added shared pytest cache isolation.

  * Added `tests/conftest.py` to isolate EPG cache files during tests.
  * Added tests for EPG cache path handling, serialization, disk save/load, stale fallback, corrupt cache handling, and cache-aware tuner loading.
  * Added tests for manual tuner cache refresh behavior.

### Changed

* Updated release metadata to `v4.9.8` with release date `2026-07-10`.
* Updated README version badge to `v4.9.8`.
* Updated Linux, Raspberry Pi, Windows batch, and Windows PowerShell installer version metadata to `4.9.8`.

* Improved **Linux installer and uninstaller behavior**.

  * Renamed the Linux systemd service from `iptv-server` to `retroiptvguide`.
  * Added legacy `iptv-server` service cleanup when the legacy unit is confirmed to belong to RetroIPTVGuide.
  * Added safeguards so uninstall does not remove the shared `iptv` user/home directory when RetroStation MC or another service using that user is detected.
  * Added RetroStation MC detection by service name, foreign `User=iptv` systemd units, and known install directories.
  * Updated install/update flow to rewrite the current systemd service and clean owned legacy service files.

* Improved guide refresh behavior.

  * Scheduled guide refresh now defers while video is actively playing, not only while fullscreen is active.
  * Added handling for embedded playback, fullscreen playback, and Picture-in-Picture.
  * Deferred refresh now runs after playback stops.
  * Added debounce logic to avoid reloads during brief buffering pauses or channel switches.

* Improved dynamic guide row preference handling.

  * Hidden, favorite, and auto-load channel row states are now reapplied when guide rows are dynamically added or removed.
  * Channel context-menu bindings are now reapplied for newly added channel rows.
  * MutationObserver now watches guide row subtree changes instead of only top-level child changes.
  * Hidden-channel visibility state is now preserved when showing hidden channels.

* Improved guide search.

  * Guide search/filter now indexes channel numbers in addition to channel names, groups, types, programs, and metadata.

* Improved mobile and responsive layout behavior.

  * Added `#pageContent` as the internal scroll container for non-guide pages.
  * Kept `#appZoomRoot` overflow hidden to avoid sticky-header issues, including iOS Safari behavior.
  * Updated display-size handling so the default 1.0x zoom still applies the required root layout styles.
  * Updated mobile video height calculations to account for whether the summary panel is expanded or collapsed.
  * Removed the separate `mobile-scroll-fix.css` include from the base template.

* Improved admin access enforcement.

  * Weather background override API is now admin-only.
  * Traffic demo city update, enable all, disable all, and random-pick actions are now admin-only.
  * Added helper logic for checking admin user status.

* Improved diagnostics and stream-detection hardening.

  * Stream detection now catches unexpected probe failures and returns a controlled JSON error instead of allowing an unhandled exception.
  * Stream detection removes raw byte data from failed fetch responses.
  * DNS failure messages are now less verbose to users.
  * Service probe logging now strips query strings, fragments, and embedded credentials before writing URLs to logs.

* Improved user-management behavior.

  * Added tests confirming non-admin users cannot access Manage Users.
  * Added tests confirming Android TV-style user agents are redirected away from Manage Users.
  * Added test coverage for assigning tuners to users.

* Updated ignored runtime/cache paths.

  * Added runtime/cache directories to `.gitignore`, including:
    * `runtime/`
    * `config/runtime/`
    * `config/cache/`
    * `config/weather/`
    * `config/epg_cache/`

* Updated roadmap status.

  * Marked **Browse mode** complete.
  * Marked **What’s On Now** complete.
  * Marked **EPG caching** complete.

### Removed

* Removed **Mini Guide overlay** from the video player.

  * Removed the semi-transparent channel list overlay that previously slid in over the video player.
  * Removed the **☰ Mini Guide** player button.
  * Removed the `G` keyboard shortcut that toggled the overlay.
  * Removed overlay-only functions from `static/js/mini-guide.js` (`openMiniGuide`, `closeMiniGuide`, `toggleMiniGuide`, auto-dismiss timer, keyboard navigation).
  * The **Mini Guide Layout** option, meaning the compact full-page list view, remains available.

### Tests

* Added `tests/conftest.py`.
* Added `tests/test_epg_cache.py`.
* Added `tests/test_install_scripts.py`.
* Added `tests/test_tuner_cache_refresh.py`.
* Updated tests for:
  * Admin diagnostics stream-detection failure handling.
  * Guide search/filter channel-number indexing.
  * Linux/Raspberry Pi installer shared-user protections.
  * Mini Guide layout behavior after overlay removal.
  * Traffic demo admin-only actions.
  * Weather background override admin-only access.
  * What’s On Now assigned-tuner behavior.
  * User preferences and assigned tuner behavior.
  * Dynamic user preference reapplication after guide row mutations.