### PR TITLE
v4.9.9 Release

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -38,6 +38,10 @@ jobs:
         flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
         flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
 
+    - name: Guard Linux installer layout assumptions
+      run: |
+        pytest tests/test_install_scripts.py
+
 #    - name: Run tests (skip if none)
 #      run: |
 #        pytest || true

--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,8 @@ config/tuners.db
 config/users.db
 config/users.db-shm
 config/users.db-wal
+runtime/
+config/runtime/
+config/cache/
+config/weather/
+config/epg_cache/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,39 @@ This project follows [Semantic Versioning](https://semver.org/).
 
 ---
 
+## v4.9.9 - 2026-07-21
+
+### Added
+- Added Linux installer coverage that guards the dedicated `retroiptvguide` service
+  account, `/opt/retroiptvguide` app path, `/etc/retroiptvguide` configuration path,
+  `/var/lib/retroiptvguide` state path, safe uninstall behavior, explicit purge behavior,
+  and CI enforcement against reintroducing shared `/home/iptv` ownership assumptions.
+
+### Changed
+- Standardized Linux installs on the isolated layout:
+  - application code and virtualenv in `/opt/retroiptvguide`
+  - administrator-managed environment file in `/etc/retroiptvguide`
+  - mutable state and app logs in `/var/lib/retroiptvguide`
+  - dedicated `retroiptvguide` service account for `retroiptvguide.service`
+- Linux migration from `/home/iptv/iptv-server` is now automatic when the v4.9.9+
+  installer or updater detects the legacy RetroIPTVGuide layout.
+- Automatic migration rewrites the current systemd unit, copies legacy application state
+  into `/var/lib/retroiptvguide`, and only removes `iptv-server.service` when that unit
+  is confirmed to belong to RetroIPTVGuide.
+- Linux uninstall now removes the service and application directory while retaining
+  `/etc/retroiptvguide`, `/var/lib/retroiptvguide`, and any untouched legacy tree for
+  reinstall or rollback. Explicit `purge` is required to remove retained config/state.
+
+### Fixed
+- Removed Linux uninstall behavior that relied on shared-user cleanup patterns such as
+  user-wide process termination or recursive user-home deletion.
+- Hardened the v4.9.9 legacy-layout migration so backup creation must succeed before
+  destructive steps continue, migrated persistent state is validated before the success
+  marker is written, legacy state conflicts are preserved explicitly, and safe cleanup
+  only runs after validation succeeds.
+
+---
+
 ## v4.9.8 - 2026-07-10
 
 ### Added

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -1,20 +1,22 @@
 # INSTALL.md
 
-This document provides detailed installation, update, and uninstall
-instructions for RetroIPTVGuide.
+This document provides detailed installation, migration, update, backup, restore,
+rollback, and removal instructions for RetroIPTVGuide.
 
 ------------------------------------------------------------------------
 
 # Docker Installation (Recommended)
 
 Pull the latest container:
-```
+```bash
 docker pull ghcr.io/thehack904/retroiptvguide:latest
 ```
+
 Run the container:
-```
+```bash
 docker run -d -p 5000:5000 ghcr.io/thehack904/retroiptvguide:latest
 ```
+
 Access the interface:
 
 http://`<server-ip>`{=html}:5000
@@ -23,35 +25,223 @@ http://`<server-ip>`{=html}:5000
 
 # Linux Installation
 
-## Option A — From a downloaded release archive (no internet required for repo files)
+## Standard Linux filesystem layout (v4.9.9+)
+
+Fresh Linux installs now use a dedicated service account and FHS-style paths:
+
+- Application code and virtual environment: `/opt/retroiptvguide`
+- Administrator-managed environment file: `/etc/retroiptvguide/retroiptvguide.env`
+- Mutable state, databases, uploads, caches, and app logs: `/var/lib/retroiptvguide`
+- Dedicated service account: `retroiptvguide`
+- systemd unit: `/etc/systemd/system/retroiptvguide.service`
+
+Expected ownership and permissions after install:
+
+- `/opt/retroiptvguide` → root-owned, mode `755`
+- `/etc/retroiptvguide` → root-owned, mode `755`
+- `/etc/retroiptvguide/retroiptvguide.env` → root-owned, mode `640`
+- `/var/lib/retroiptvguide` → `retroiptvguide:retroiptvguide`, mode `750`
+
+## Fresh install
+
+### Option A — From a downloaded release archive
 
 Download the release `.zip` or `.tar.gz` from the
 [Releases page](https://github.com/thehack904/RetroIPTVGuide/releases), extract it,
 then run the installer from inside the extracted directory:
 
 ```bash
-# Example using v4.9.4
-wget https://github.com/thehack904/RetroIPTVGuide/archive/refs/tags/v4.9.4.tar.gz
-tar -xzf v4.9.4.tar.gz
-cd RetroIPTVGuide-4.9.4
+# Example using v4.9.9
+wget https://github.com/thehack904/RetroIPTVGuide/archive/refs/tags/v4.9.9.tar.gz
+tar -xzf v4.9.9.tar.gz
+cd RetroIPTVGuide-4.9.9
 sudo bash retroiptv_linux.sh install --agree
 ```
 
 The installer detects that `app.py` and `requirements.txt` are present alongside the
 script and uses those files directly — no `git clone` is performed.
 
-## Option B — Direct curl one-liner (clones from GitHub)
+### Option B — Direct curl one-liner
 
-```
+```bash
 curl -sSL https://raw.githubusercontent.com/thehack904/RetroIPTVGuide/main/retroiptv_linux.sh | sudo bash -s install --agree --yes
 ```
 
 If the full repository is **not** detected in the current directory the installer will
 ask for confirmation before cloning from GitHub. Pass `--yes` to skip the prompt.
 
-Default install location:
+## Dedicated service-account behavior
 
-/home/iptv/iptv-server
+- The Linux installer creates the `retroiptvguide` system account if needed.
+- The service runs as `retroiptvguide`, not as the legacy shared `iptv` account.
+- The installer writes `RETROIPTV_DATA_DIR=/var/lib/retroiptvguide` into
+  `/etc/retroiptvguide/retroiptvguide.env`.
+- The systemd unit loads that environment file and starts the app from
+  `/opt/retroiptvguide`.
+
+## Upgrade from `/home/iptv/iptv-server`
+
+Linux migration is **automatic** when the v4.9.9+ Linux installer or updater sees the
+legacy RetroIPTVGuide layout.
+
+The migration flow:
+
+1. Detects the legacy installation and creates a timestamped pre-migration backup under
+   `/var/backups/retroiptvguide-migration-*`
+2. Copies legacy state from `/home/iptv/iptv-server/config` into `/var/lib/retroiptvguide`
+   and moves legacy uploads and generated road/map caches into the corresponding
+   `/var/lib/retroiptvguide/uploads` and `/var/lib/retroiptvguide/cache` directories
+3. Preserves any conflicting legacy state files in a clearly named migration-conflicts
+   directory instead of silently overwriting either version
+4. Writes the dedicated-account environment and systemd configuration for
+   `retroiptvguide.service`
+5. Validates the migrated installation and persistent state before writing the
+   `.migration_v4.9.9` success marker
+6. Removes the legacy `iptv-server.service` unit **only** when it is confirmed to belong
+   to RetroIPTVGuide
+7. Removes `/home/iptv/iptv-server` only when the migration succeeded and shared-user /
+   RetroStation MC safeguards confirm nothing else still depends on the legacy path
+
+The migration does **not** delete sibling projects, shared `/home/iptv` directories, or
+the legacy shared `iptv` account.
+
+## Updating
+
+Linux:
+```bash
+sudo /opt/retroiptvguide/retroiptv_linux.sh update --yes
+```
+
+Raspberry Pi:
+```bash
+sudo /home/iptv/iptv-server/retroiptv_rpi.sh update --yes
+```
+
+Docker:
+```bash
+docker pull ghcr.io/thehack904/retroiptvguide:latest
+```
+
+Restart the container after pulling the new image.
+
+## Backup and restore
+
+### Back up the Linux install
+
+```bash
+sudo systemctl stop retroiptvguide
+sudo tar -C /opt -czf retroiptvguide-app.tgz retroiptvguide
+sudo tar -C /etc -czf retroiptvguide-etc.tgz retroiptvguide
+sudo tar -C /var/lib -czf retroiptvguide-state.tgz retroiptvguide
+sudo systemctl start retroiptvguide
+```
+
+At minimum, preserve `/etc/retroiptvguide` and `/var/lib/retroiptvguide` before major
+upgrades or host maintenance.
+
+### Restore the Linux install
+
+```bash
+sudo systemctl stop retroiptvguide
+sudo tar -C /opt -xzf retroiptvguide-app.tgz
+sudo tar -C /etc -xzf retroiptvguide-etc.tgz
+sudo tar -C /var/lib -xzf retroiptvguide-state.tgz
+sudo chown -R root:root /opt/retroiptvguide
+sudo chown -R retroiptvguide:retroiptvguide /var/lib/retroiptvguide
+sudo systemctl daemon-reload
+sudo systemctl start retroiptvguide
+```
+
+## Rollback procedure
+
+If you need to recover after the Linux layout migration:
+
+1. Stop the new service:
+   ```bash
+   sudo systemctl stop retroiptvguide
+   sudo systemctl disable retroiptvguide
+   ```
+2. Restore the installer-created pre-migration backup from
+   `/var/backups/retroiptvguide-migration-*/legacy-state.tar.gz` and any other host
+   backups you maintain.
+3. Reinstall or restore the older RetroIPTVGuide release from your saved archive.
+4. Recreate or restore the legacy `iptv-server.service` unit before starting the legacy
+   deployment.
+
+The legacy `/home/iptv/iptv-server` tree may already have been removed if the installer
+determined that no other shared-user components still depended on it, so the migration
+backup is the primary rollback copy when cleanup occurs.
+
+## systemd status, logs, and troubleshooting
+
+Useful commands:
+
+```bash
+sudo systemctl status retroiptvguide
+sudo journalctl -u retroiptvguide -n 200 --no-pager
+sudo journalctl -u retroiptvguide -f
+sudo cat /etc/retroiptvguide/retroiptvguide.env
+sudo ls -la /opt/retroiptvguide /etc/retroiptvguide /var/lib/retroiptvguide
+```
+
+Troubleshooting checklist:
+
+- Confirm the service account exists: `id retroiptvguide`
+- Confirm the app path exists: `ls /opt/retroiptvguide`
+- Confirm the data path is writable by the service account:
+  `sudo -u retroiptvguide test -w /var/lib/retroiptvguide`
+- Confirm the unit points to `/opt/retroiptvguide` and the dedicated account:
+  `sudo systemctl cat retroiptvguide`
+- The unit uses `ProtectSystem=strict`; only the state and runtime directories are
+  writable. Upload and generated-cache paths are symlinked into the state directory
+  during installation, so they remain writable without a systemd mount namespace.
+
+## Safe uninstall vs explicit purge
+
+### Safe uninstall
+
+```bash
+sudo /opt/retroiptvguide/retroiptv_linux.sh uninstall --yes
+```
+
+Safe uninstall removes:
+
+- `retroiptvguide.service`
+- `/opt/retroiptvguide`
+- firewall and SELinux adjustments made by the installer
+
+Safe uninstall retains:
+
+- `/etc/retroiptvguide`
+- `/var/lib/retroiptvguide`
+- the dedicated `retroiptvguide` account
+- any retained legacy `/home/iptv/iptv-server` tree that was not already cleaned up
+
+### Explicit purge
+
+```bash
+sudo /opt/retroiptvguide/retroiptv_linux.sh purge --yes
+```
+
+Purge additionally removes:
+
+- `/etc/retroiptvguide`
+- `/var/lib/retroiptvguide`
+- any retained legacy `/home/iptv/iptv-server`
+- the dedicated `retroiptvguide` account and group
+
+Purge still leaves the shared legacy `iptv` account alone so sibling projects are not
+broken by RetroIPTVGuide removal.
+
+## Coexistence with sibling projects and RetroStation Player
+
+The v4.9.9+ Linux layout is intentionally isolated:
+
+- RetroIPTVGuide no longer installs its code under `/home/iptv`
+- RetroIPTVGuide no longer runs as the shared `iptv` account
+- The installer only removes `iptv-server.service` when that legacy unit is confirmed
+  to belong to RetroIPTVGuide
+- The installer does not target RetroStation Player or sibling project directories
 
 ------------------------------------------------------------------------
 
@@ -70,7 +260,7 @@ The installer detects the local release files and skips the GitHub clone step.
 
 ## Option B — Direct curl one-liner (clones from GitHub)
 
-```
+```bash
 curl -sSL https://raw.githubusercontent.com/thehack904/RetroIPTVGuide/main/retroiptv_rpi.sh | sudo bash -s install --agree --yes
 ```
 
@@ -79,9 +269,9 @@ ask for confirmation before cloning. Pass `--yes` to skip the prompt.
 
 Supported hardware:
 
--   Raspberry Pi 3
--   Raspberry Pi 4
--   Raspberry Pi 5
+- Raspberry Pi 3
+- Raspberry Pi 4
+- Raspberry Pi 5
 
 ------------------------------------------------------------------------
 
@@ -113,39 +303,6 @@ Invoke-WebRequest https://raw.githubusercontent.com/thehack904/RetroIPTVGuide/ma
 
 If the full repository is **not** detected in the current directory the installer will
 ask for confirmation before cloning from GitHub. Pass `--yes` to skip the prompt.
-------------------------------------------------------------------------
-
-# Updating
-
-Linux
-```
-sudo /home/iptv/iptv-server/retroiptv_linux.sh update --yes
-```
-Raspberry Pi
-```
-sudo /home/iptv/iptv-server/retroiptv_rpi.sh update --yes
-```
-Docker
-```
-docker pull ghcr.io/thehack904/retroiptvguide:latest
-```
-Restart the container after pulling the new image.
-
-------------------------------------------------------------------------
-
-# Uninstall
-
-Linux
-```
-sudo /home/iptv/iptv-server/retroiptv_linux.sh uninstall --yes
-```
-Raspberry Pi
-```
-sudo /home/iptv/iptv-server/retroiptv_rpi.sh uninstall --yes
-```
-Windows
-
-Run the installer again and select **Uninstall**.
 
 ------------------------------------------------------------------------
 
@@ -156,41 +313,50 @@ Password: strongpassword123
 
 Change the password after the first login.
 
-
 ------------------------------------------------------------------------
 
 ## 🔐 Admin Password Recovery
 
 If the admin password is lost, it can be reset using the provided script.
 
-### Reset Command
+### Reset command
 
-python3 /home/iptv/iptv-server/scripts/reset_admin_password.py --db /home/iptv/iptv-server/config/users.db
+```bash
+python3 /opt/retroiptvguide/scripts/reset_admin_password.py --db /var/lib/retroiptvguide/users.db
+```
 
-### Common Permission Issue
+### Common permission issue
 
 If you see a database write error, it is likely due to ownership mismatch.
 
-Example error:
-- File owned by: iptv
-- Current user: anotheruser
+Example:
 
-Run the script as the correct user:
+- Database owned by: `retroiptvguide`
+- Current user: another account
 
-sudo -u iptv python3 /home/iptv/iptv-server/scripts/reset_admin_password.py --db /home/iptv/iptv-server/config/users.db
+Run the script as the dedicated service account:
 
-### Immutable File Check (Rare)
+```bash
+sudo -u retroiptvguide python3 /opt/retroiptvguide/scripts/reset_admin_password.py --db /var/lib/retroiptvguide/users.db
+```
+
+### Immutable file check (rare)
 
 If the issue persists, check if the file is immutable:
 
-lsattr /home/iptv/iptv-server/config/users.db
+```bash
+lsattr /var/lib/retroiptvguide/users.db
+```
 
 If an `i` flag is present, remove it:
 
-sudo chattr -i /home/iptv/iptv-server/config/users.db
+```bash
+sudo chattr -i /var/lib/retroiptvguide/users.db
+```
 
 ### Result
 
 On success:
+
 - Password is reset
 - Admin is required to change password on next login

--- a/PROJECT_STRUCTURE.md
+++ b/PROJECT_STRUCTURE.md
@@ -52,6 +52,26 @@ Configuration is typically stored in:
 - local configuration files
 - database tables
 
+### Linux deployment layout (v4.9.9+)
+
+The repository layout above is separate from the standardized Linux runtime layout:
+
+- `/opt/retroiptvguide`
+  - application code
+  - Python virtual environment
+  - installer scripts
+- `/etc/retroiptvguide`
+  - administrator-managed environment overrides
+  - `retroiptvguide.env`
+- `/var/lib/retroiptvguide`
+  - mutable application state
+  - SQLite databases
+  - caches and runtime support files
+  - application log files
+
+The Linux systemd unit remains `retroiptvguide.service` and runs as the dedicated
+`retroiptvguide` service account rather than the legacy shared `iptv` user.
+
 ---
 
 ## Static Asset Organization

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 <p align="center">
   <a href="https://github.com/thehack904/RetroIPTVGuide">
-    <img src="https://img.shields.io/badge/version-v4.9.8-blue?style=for-the-badge" alt="Version">
+    <img src="https://img.shields.io/badge/version-v4.9.9-blue?style=for-the-badge" alt="Version">
   </a>
   <a href="https://github.com/thehack904/RetroIPTVGuide/pkgs/container/retroiptvguide">
     <img src="https://img.shields.io/badge/GHCR-ghcr.io/thehack904/retroiptvguide-green?style=for-the-badge&logo=docker" alt="GHCR">
@@ -108,6 +108,38 @@ You will be required to change this password immediately on first login.
 ## 🔐 Admin Password Reset
 
 If you lose access to the admin account, see: INSTALL.md → Admin Password Recovery
+
+------------------------------------------------------------------------
+
+## 🐧 Linux Layout Migration (v4.9.9+)
+
+Linux installs now use an isolated filesystem layout and dedicated service account:
+
+- App + venv: `/opt/retroiptvguide`
+- Admin-managed environment file: `/etc/retroiptvguide/retroiptvguide.env`
+- Mutable state, uploads, caches, and app logs: `/var/lib/retroiptvguide`
+- Service account: `retroiptvguide`
+- systemd unit: `retroiptvguide.service`
+
+If you are upgrading from `/home/iptv/iptv-server`, the Linux installer/update flow
+automatically creates a timestamped pre-migration backup under
+`/var/backups/retroiptvguide-migration-*`, migrates legacy state into
+`/var/lib/retroiptvguide`, and only removes the legacy `iptv-server.service` when it is
+confirmed to belong to RetroIPTVGuide. The legacy `/home/iptv/iptv-server` tree may be
+removed after a successful validated migration when nothing else still depends on the
+shared legacy `iptv` account or path, so the backup is the primary rollback copy when
+cleanup occurs.
+
+Useful Linux commands:
+
+```bash
+sudo /opt/retroiptvguide/retroiptv_linux.sh update --yes
+sudo systemctl status retroiptvguide
+sudo journalctl -u retroiptvguide -f
+```
+
+See [INSTALL.md](INSTALL.md) for backup/restore, rollback, uninstall vs purge, and
+coexistence guidance for sibling projects and RetroStation Player.
 
 ------------------------------------------------------------------------
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -5,7 +5,7 @@ These are **not yet implemented**, partially implemented, or completed in previo
 
 ---
 
-# Current Version: **v4.9.8 (2026-07-10)**
+# Current Version: **v4.9.9 (2026-07-21)**
 
 ---
 

--- a/app.py
+++ b/app.py
@@ -1,6 +1,6 @@
 # app.py — merged version (features from both sources)
-APP_VERSION = "v4.9.8"
-APP_RELEASE_DATE = "2026-07-10"
+APP_VERSION = "v4.9.9"
+APP_RELEASE_DATE = "2026-07-21"
 
 from flask import Flask, render_template, request, redirect, url_for, flash, session, jsonify, abort, make_response, g
 from flask_login import LoginManager, UserMixin, login_user, login_required, logout_user, current_user
@@ -63,6 +63,18 @@ def _resolve_data_dir() -> str:
 
 DATA_DIR = _resolve_data_dir()
 
+# Emit a clear non-fatal warning when the application is running from the
+# deprecated legacy layout (/home/iptv/iptv-server) so operators know
+# migration is required without adding duplicate startup noise.
+_APP_FILE = os.path.abspath(__file__)
+if _APP_FILE.startswith("/home/iptv/iptv-server"):
+    print(
+        "[RetroIPTVGuide] WARNING: Running from deprecated legacy path "
+        "/home/iptv/iptv-server. Please migrate to the supported "
+        "/opt/retroiptvguide layout using: sudo ./retroiptv_linux.sh install",
+        file=sys.stderr,
+    )
+
 # Ensure required subdirectories exist
 for _subdir in ("logs", "db", "xmltv", "support"):
     _subdir_path = os.path.join(DATA_DIR, _subdir)
@@ -107,7 +119,7 @@ EPG_DISK_CACHE_TTL = 86400  # 24 hours — default on-disk TTL for EPG data
 ROADS_BUNDLED_DIR = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'static', 'data', 'roads')
 AUDIO_UPLOAD_DIR = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'static', 'audio')
 _ALLOWED_AUDIO_EXTENSIONS = {'mp3', 'ogg', 'wav', 'aac', 'm4a', 'flac'}
-LOGO_UPLOAD_DIR = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'static', 'logos', 'virtual')
+LOGO_UPLOAD_DIR = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'static', 'logos', 'virtual', 'uploads')
 ICON_PACK_DIR = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'static', 'logos', 'virtual', 'icon_pack')
 _ALLOWED_LOGO_EXTENSIONS = {'png', 'jpg', 'jpeg', 'gif', 'svg', 'webp'}
 
@@ -3407,7 +3419,7 @@ def _resolve_channel_logo(tvg_id, default_logo, custom_filename, use_icon_pack):
     3. Default SVG logo (fallback)
     """
     if custom_filename:
-        return f'/static/logos/virtual/{custom_filename}'
+        return f'/static/logos/virtual/uploads/{custom_filename}'
     if use_icon_pack:
         pack_url = _ICON_PACK_LOGOS.get(tvg_id)
         if pack_url:
@@ -6089,7 +6101,7 @@ def api_logo_upload():
         logging.warning("api_logo_upload: invalid logo for %s: %s", tvg_id, exc)
         return jsonify({'error': 'Invalid logo file.'}), 400
     log_event(current_user.username, f"Uploaded logo for {tvg_id}: {dest_name}")
-    return jsonify({'ok': True, 'filename': dest_name, 'url': f'/static/logos/virtual/{dest_name}'}), 201
+    return jsonify({'ok': True, 'filename': dest_name, 'url': f'/static/logos/virtual/uploads/{dest_name}'}), 201
 
 
 @app.route('/api/logo/reset/<tvg_id>', methods=['POST'])

--- a/docs/wiki/FAQ.md
+++ b/docs/wiki/FAQ.md
@@ -180,8 +180,8 @@ separate resizable window.
 ### How do I update RetroIPTVGuide?
 
 - **Docker:** `docker compose pull && docker compose up -d`
-- **Linux:** `sudo /home/iptv/iptv-server/retroiptv_linux.sh update --yes`
-- **Raspberry Pi:** `sudo /home/iptv/iptv-server/retroiptv_rpi.sh update --yes`
+- **Linux:** `sudo /opt/retroiptvguide/retroiptv_linux.sh update --yes`
+- **Raspberry Pi:** `sudo /home/iptv/iptv-server/retroiptv_rpi.sh update --yes` (Raspberry Pi path unchanged)
 
 ### Where can I find the release history?
 

--- a/docs/wiki/Installation.md
+++ b/docs/wiki/Installation.md
@@ -75,18 +75,37 @@ If the full repository is **not** detected in the current directory the installe
 will ask for confirmation before cloning from GitHub. Pass `--yes` to skip the
 prompt in non-interactive environments.
 
-Default install location: `/home/iptv/iptv-server`
+Default Linux layout:
+
+- App + venv: `/opt/retroiptvguide`
+- Admin-managed environment file: `/etc/retroiptvguide/retroiptvguide.env`
+- Mutable state, uploads, and caches: `/var/lib/retroiptvguide`
+- Dedicated service account: `retroiptvguide`
+
+When the Linux installer or updater sees a legacy `/home/iptv/iptv-server` deployment,
+it creates a timestamped pre-migration backup under
+`/var/backups/retroiptvguide-migration-*`, migrates state into
+`/var/lib/retroiptvguide`, rewrites `retroiptvguide.service`, and may remove the legacy
+RetroIPTVGuide directory after a successful validated migration when nothing else still
+depends on the shared legacy `iptv` account or path. If shared resources are still in
+use by RetroStation MC or another sibling service, those shared resources are retained.
 
 ### Update
 
 ```bash
-sudo /home/iptv/iptv-server/retroiptv_linux.sh update --yes
+sudo /opt/retroiptvguide/retroiptv_linux.sh update --yes
 ```
 
 ### Uninstall
 
 ```bash
-sudo /home/iptv/iptv-server/retroiptv_linux.sh uninstall --yes
+sudo /opt/retroiptvguide/retroiptv_linux.sh uninstall --yes
+```
+
+### Purge
+
+```bash
+sudo /opt/retroiptvguide/retroiptv_linux.sh purge --yes
 ```
 
 ---
@@ -178,15 +197,15 @@ You are required to change the password immediately after the first login.
 If the admin password is lost it can be reset from the command line.
 
 ```bash
-python3 /home/iptv/iptv-server/scripts/reset_admin_password.py \
-  --db /home/iptv/iptv-server/config/users.db
+python3 /opt/retroiptvguide/scripts/reset_admin_password.py \
+  --db /var/lib/retroiptvguide/users.db
 ```
 
 Run as the user that owns the database file to avoid permission errors:
 
 ```bash
-sudo -u iptv python3 /home/iptv/iptv-server/scripts/reset_admin_password.py \
-  --db /home/iptv/iptv-server/config/users.db
+sudo -u retroiptvguide python3 /opt/retroiptvguide/scripts/reset_admin_password.py \
+  --db /var/lib/retroiptvguide/users.db
 ```
 
 On success the admin password is reset and the account is flagged to require a

--- a/docs/wiki/Troubleshooting.md
+++ b/docs/wiki/Troubleshooting.md
@@ -89,11 +89,11 @@ downloaded and offers to clone from GitHub.
 
 If the admin password is unknown it can be reset from the command line.
 
-**Linux / Raspberry Pi:**
+**Linux (v4.9.9+ layout):**
 
 ```bash
-sudo -u iptv python3 /home/iptv/iptv-server/scripts/reset_admin_password.py \
-  --db /home/iptv/iptv-server/config/users.db
+sudo -u retroiptvguide python3 /opt/retroiptvguide/scripts/reset_admin_password.py \
+  --db /var/lib/retroiptvguide/users.db
 ```
 
 **Docker:**
@@ -112,9 +112,9 @@ If the script reports a database write error, run it as the user that owns the
 database file:
 
 ```bash
-ls -la /home/iptv/iptv-server/config/users.db
-sudo -u iptv python3 /home/iptv/iptv-server/scripts/reset_admin_password.py \
-  --db /home/iptv/iptv-server/config/users.db
+ls -la /var/lib/retroiptvguide/users.db
+sudo -u retroiptvguide python3 /opt/retroiptvguide/scripts/reset_admin_password.py \
+  --db /var/lib/retroiptvguide/users.db
 ```
 
 ### Immutable File (Rare)
@@ -122,13 +122,13 @@ sudo -u iptv python3 /home/iptv/iptv-server/scripts/reset_admin_password.py \
 If the issue persists, check if the file has been made immutable:
 
 ```bash
-lsattr /home/iptv/iptv-server/config/users.db
+lsattr /var/lib/retroiptvguide/users.db
 ```
 
 Remove the immutable flag if present:
 
 ```bash
-sudo chattr -i /home/iptv/iptv-server/config/users.db
+sudo chattr -i /var/lib/retroiptvguide/users.db
 ```
 
 ---

--- a/retroiptv_linux.sh
+++ b/retroiptv_linux.sh
@@ -3,7 +3,7 @@
 # License: Creative Commons Attribution-NonCommercial-ShareAlike 4.0 International (CC BY-NC-SA 4.0)
 
 set -euo pipefail
-VERSION="4.9.8"
+VERSION="4.9.9"
 TIMESTAMP=$(date +"%Y-%m-%d_%H-%M-%S")
 LOGFILE="retroiptv_${TIMESTAMP}.log"
 exec > >(tee -a "$LOGFILE") 2>&1
@@ -39,10 +39,18 @@ for arg in "$@"; do
 done
 [[ $(id -u) -ne 0 ]] && { echo "Run as root (sudo)."; exit 1; }
 
-APP_USER="iptv"; APP_HOME="/home/$APP_USER"; APP_DIR=""
+APP_USER="retroiptvguide"; APP_HOME="/var/lib/$APP_USER"
+APP_DIR="/opt/retroiptvguide"; CONFIG_DIR="/etc/retroiptvguide"; STATE_DIR="/var/lib/retroiptvguide"
+ENV_FILE="$CONFIG_DIR/retroiptvguide.env"; LOG_DIR_LINUX="$STATE_DIR/logs"; PYCACHE_DIR="$STATE_DIR/pycache"
+UPLOAD_DIR="$STATE_DIR/uploads"; AUDIO_UPLOAD_DIR="$UPLOAD_DIR/audio"; LOGO_UPLOAD_DIR="$UPLOAD_DIR/logos/virtual"
+CACHE_DIR="$STATE_DIR/cache"; ROADS_CACHE_DIR="$CACHE_DIR/roads"; BASEMAP_CACHE_DIR="$CACHE_DIR/traffic_demo"
+RUNTIME_DIR="/run/retroiptvguide"; STAGING_TMP_DIR="/tmp/retroiptvguide"
 SERVICE_NAME="retroiptvguide"; SYSTEMD_FILE="/etc/systemd/system/${SERVICE_NAME}.service"
 LEGACY_SERVICE_NAME="iptv-server"; LEGACY_SYSTEMD_FILE="/etc/systemd/system/${LEGACY_SERVICE_NAME}.service"
-LOG_DIR_LINUX="/var/log/iptv"
+LEGACY_APP_USER="iptv"; LEGACY_APP_HOME="/home/$LEGACY_APP_USER"; LEGACY_APP_DIR="$LEGACY_APP_HOME/iptv-server"
+LEGACY_CONFIG_DIR="$LEGACY_APP_DIR/config"; LEGACY_RUNTIME_DIR="$LEGACY_APP_DIR/runtime"; LEGACY_LOG_DIR="/var/log/iptv"
+LEGACY_AUDIO_UPLOAD_DIR="$LEGACY_APP_DIR/static/audio"; LEGACY_LOGO_UPLOAD_DIR="$LEGACY_APP_DIR/static/logos/virtual"
+LEGACY_ROADS_CACHE_DIR="$LEGACY_APP_DIR/data/roads_cache"; LEGACY_BASEMAP_CACHE_DIR="$LEGACY_APP_DIR/static/maps/traffic_demo"
 
 # --- OS detection ------------------------------------------------------------
 DISTRO_ID=""
@@ -50,19 +58,16 @@ DISTRO_ID=""
 
 case "$DISTRO_ID" in
   ubuntu|debian|raspbian)
-    PKG_MANAGER="apt"; PKG_INSTALL="apt-get install -y"; PKG_UPDATE="apt-get update -y"; APP_DIR_DEFAULT="$APP_HOME/iptv-server" ;;
+    PKG_MANAGER="apt"; PKG_INSTALL="apt-get install -y"; PKG_UPDATE="apt-get update -y" ;;
   rhel|centos|rocky|almalinux|fedora)
     PKG_MANAGER=$(command -v dnf >/dev/null 2>&1 && echo dnf || echo yum)
-    PKG_INSTALL="$PKG_MANAGER install -y"; PKG_UPDATE="$PKG_MANAGER -y makecache && $PKG_MANAGER upgrade -y || true"
-    APP_DIR_DEFAULT="/opt/retroiptvguide" ;;
+    PKG_INSTALL="$PKG_MANAGER install -y"; PKG_UPDATE="$PKG_MANAGER -y makecache && $PKG_MANAGER upgrade -y || true" ;;
   *) PKG_MANAGER=$(command -v apt-get >/dev/null 2>&1 && echo apt || echo dnf)
-     PKG_INSTALL="$PKG_MANAGER install -y"; PKG_UPDATE="$PKG_MANAGER -y makecache || true"
-     APP_DIR_DEFAULT="/opt/retroiptvguide" ;;
+     PKG_INSTALL="$PKG_MANAGER install -y"; PKG_UPDATE="$PKG_MANAGER -y makecache || true" ;;
 esac
-APP_DIR="$APP_DIR_DEFAULT"
 
 # --- Utility Functions -------------------------------------------------------
-usage(){ echo "Usage: sudo $0 [install|update|uninstall] [--agree|-a] [--yes|-y]"; }
+usage(){ echo "Usage: sudo $0 [install|update|uninstall|purge] [--agree|-a] [--yes|-y]"; }
 
 agree_terms() {
   # Skip if user pre-agreed
@@ -80,10 +85,11 @@ agree_terms() {
   echo "  - Detect whether you are running on Linux, WSL, or Git Bash"
   echo "  - On Linux/WSL:"
   echo "      * Ensure the script is run with sudo"
-  echo "      * Create dedicated system user 'iptv' (if not already present)"
+  echo "      * Create dedicated system user 'retroiptvguide' (if not already present)"
   echo "      * Ensure python3-venv package is installed"
-  echo "      * Copy project files into /home/iptv/iptv-server (Debian/Ubuntu)"
-  echo "      * Copy project files into /opt/retroiptvguide (Fedora/RHEL)"
+  echo "      * Copy project files into /opt/retroiptvguide"
+  echo "      * Store admin-managed environment overrides in /etc/retroiptvguide"
+  echo "      * Store mutable state in /var/lib/retroiptvguide"
   echo "      * Create and configure a Python virtual environment"
   echo "      * Upgrade pip and install requirements"
   echo "      * Create and enable the retroiptvguide systemd service"
@@ -112,21 +118,297 @@ ensure_packages(){
   eval "$PKG_UPDATE"; eval "$PKG_INSTALL ${pkgs[*]}"
 }
 
+require_command(){
+  local cmd="$1"
+  command -v "$cmd" >/dev/null 2>&1 || {
+    echo "Required command '$cmd' is missing. Install it and re-run this script."
+    exit 1
+  }
+}
+
 ensure_user(){
   echo "Ensuring system user..."
   NOLOGIN=$(command -v nologin 2>/dev/null || echo /usr/sbin/nologin)
   getent group "$APP_USER" >/dev/null || groupadd --system "$APP_USER"
   if ! id "$APP_USER" >/dev/null 2>&1; then
-    useradd -r -m -d "$APP_HOME" -s "$NOLOGIN" -g "$APP_USER" "$APP_USER"
+    useradd -r -M -d "$APP_HOME" -s "$NOLOGIN" -g "$APP_USER" "$APP_USER"
   fi
-  chmod 755 "$APP_HOME" || true
+}
+
+ensure_layout_dirs(){
+  echo "Ensuring application layout..."
+  install -d -m 755 -o root -g root "$APP_DIR"
+  install -d -m 755 -o root -g root "$CONFIG_DIR"
+  install -d -m 750 -o "$APP_USER" -g "$APP_USER" "$STATE_DIR"
+  install -d -m 750 -o "$APP_USER" -g "$APP_USER" "$LOG_DIR_LINUX"
+  install -d -m 750 -o "$APP_USER" -g "$APP_USER" "$PYCACHE_DIR"
+  install -d -m 750 -o "$APP_USER" -g "$APP_USER" "$AUDIO_UPLOAD_DIR"
+  install -d -m 750 -o "$APP_USER" -g "$APP_USER" "$LOGO_UPLOAD_DIR"
+  install -d -m 750 -o "$APP_USER" -g "$APP_USER" "$ROADS_CACHE_DIR"
+  install -d -m 750 -o "$APP_USER" -g "$APP_USER" "$BASEMAP_CACHE_DIR"
+}
+
+write_environment_file(){
+  if [[ -f "$ENV_FILE" ]]; then
+    if grep -Eq '^RETROIPTV_DATA_DIR=' "$ENV_FILE"; then
+      sed -i "s|^RETROIPTV_DATA_DIR=.*$|RETROIPTV_DATA_DIR=$STATE_DIR|" "$ENV_FILE"
+    else
+      printf '\nRETROIPTV_DATA_DIR=%s\n' "$STATE_DIR" >>"$ENV_FILE"
+    fi
+  else
+    cat >"$ENV_FILE"<<EOF
+# RetroIPTVGuide environment overrides
+RETROIPTV_DATA_DIR=$STATE_DIR
+EOF
+  fi
+  chown root:root "$ENV_FILE"
+  chmod 640 "$ENV_FILE"
+}
+
+MIGRATION_MARKER="$STATE_DIR/.migration_v4.9.9"
+MIGRATION_BACKUP_DIR="/var/backups/retroiptvguide-migration-${TIMESTAMP}"
+MIGRATION_EXPECTED_STATE_MANIFEST="$MIGRATION_BACKUP_DIR/expected-state-files.txt"
+MIGRATION_CONFLICT_DIR="$STATE_DIR/migration-conflicts/v4.9.9-${TIMESTAMP}"
+MIGRATION_CONFLICT_MANIFEST="$MIGRATION_BACKUP_DIR/conflicted-state-files.txt"
+MIGRATION_DETECTED=false
+MIGRATION_MARKER_WRITTEN=false
+
+migration_marker_is_valid(){
+  [[ -f "$MIGRATION_MARKER" ]] && grep -Fqx "migration_version=$VERSION" "$MIGRATION_MARKER"
+}
+
+record_expected_legacy_state(){
+  : > "$MIGRATION_EXPECTED_STATE_MANIFEST"
+  record_expected_directory "$LEGACY_CONFIG_DIR" ""
+  record_expected_directory "$LEGACY_RUNTIME_DIR" "runtime"
+  record_expected_directory "$LEGACY_AUDIO_UPLOAD_DIR" "uploads/audio"
+  record_expected_directory "$LEGACY_LOGO_UPLOAD_DIR" "uploads/logos/virtual"
+  record_expected_directory "$LEGACY_ROADS_CACHE_DIR" "cache/roads"
+  record_expected_directory "$LEGACY_BASEMAP_CACHE_DIR" "cache/traffic_demo"
+}
+
+record_expected_directory(){
+  local source_dir="$1" target_prefix="$2"
+  [[ -d "$source_dir" ]] || return 0
+  while IFS= read -r -d '' legacy_file; do
+    [[ "$source_dir" == "$LEGACY_LOGO_UPLOAD_DIR" && "$legacy_file" == "$LEGACY_LOGO_UPLOAD_DIR/icon_pack/"* ]] && continue
+    local rel_path="${legacy_file#"$source_dir"/}"
+    printf '%s\n' "${target_prefix:+$target_prefix/}$rel_path" >> "$MIGRATION_EXPECTED_STATE_MANIFEST"
+  done < <(find "$source_dir" -type f -print0 2>/dev/null)
+}
+
+preserve_legacy_directory_conflicts(){
+  local source_dir="$1" target_dir="$2" target_prefix="$3"
+  [[ -d "$source_dir" ]] || return 0
+  while IFS= read -r -d '' legacy_file; do
+    local rel_path dest_path conflict_path
+    [[ "$source_dir" == "$LEGACY_LOGO_UPLOAD_DIR" && "$legacy_file" == "$LEGACY_LOGO_UPLOAD_DIR/icon_pack/"* ]] && continue
+    rel_path="${legacy_file#"$source_dir"/}"
+    dest_path="$target_dir/$rel_path"
+
+    if [[ -e "$dest_path" || -L "$dest_path" ]]; then
+      conflict_path="$MIGRATION_CONFLICT_DIR/${target_prefix:+$target_prefix/}$rel_path"
+      install -d -m 750 -o "$APP_USER" -g "$APP_USER" "$(dirname "$conflict_path")"
+      cp -p "$legacy_file" "$conflict_path"
+      printf '%s\n' "${target_prefix:+$target_prefix/}$rel_path" >> "$MIGRATION_CONFLICT_MANIFEST"
+      echo "⚠️  Migration conflict for $dest_path — keeping the existing destination file and preserving the legacy copy at $conflict_path."
+    fi
+  done < <(find "$source_dir" -type f -print0 2>/dev/null)
+}
+
+write_migration_marker(){
+  printf 'migration_version=%s\ntimestamp=%s\nbackup_dir=%s\n' \
+    "$VERSION" "$(date -u +"%Y-%m-%dT%H:%M:%SZ")" "$MIGRATION_BACKUP_DIR" > "$MIGRATION_MARKER"
+  chown "$APP_USER":"$APP_USER" "$MIGRATION_MARKER"
+  MIGRATION_MARKER_WRITTEN=true
+  echo "✅ Migration marker written: $MIGRATION_MARKER"
+}
+
+cleanup_legacy_installation_if_migration_complete(){
+  if migration_marker_is_valid; then
+    cleanup_legacy_service_if_owned
+    cleanup_legacy_app_dir_if_unshared
+  elif [[ "$MIGRATION_DETECTED" == true ]]; then
+    echo "Skipping legacy cleanup because the migration did not complete successfully."
+  fi
+}
+
+# ---------------------------------------------------------------------------
+# _migration_backup — create a timestamped tar.gz backup of all legacy paths
+# before any migration step modifies or removes them.
+# ---------------------------------------------------------------------------
+_migration_backup(){
+  echo "Creating pre-migration backup in $MIGRATION_BACKUP_DIR ..."
+  install -d -m 700 -o root -g root "$MIGRATION_BACKUP_DIR"
+  record_expected_legacy_state
+  : > "$MIGRATION_CONFLICT_MANIFEST"
+
+  local backup_paths=()
+  [[ -d "$LEGACY_APP_DIR" ]]      && backup_paths+=("$LEGACY_APP_DIR")
+  [[ -f "$LEGACY_SYSTEMD_FILE" ]] && backup_paths+=("$LEGACY_SYSTEMD_FILE")
+  [[ -d "$LEGACY_LOG_DIR" ]]      && backup_paths+=("$LEGACY_LOG_DIR")
+
+  if [[ "${#backup_paths[@]}" -eq 0 ]]; then
+    echo "No legacy paths found; skipping backup."
+    return
+  fi
+
+  # Tar preserves ownership, permissions, and timestamps (-p).
+  if ! tar -czp \
+    --exclude="$LEGACY_APP_DIR/venv" \
+    -f "$MIGRATION_BACKUP_DIR/legacy-state.tar.gz" \
+    "${backup_paths[@]}" 2>/dev/null; then
+    echo "❌ Pre-migration backup creation failed. Migration aborted; the legacy installation was left untouched."
+    return 1
+  fi
+
+  if [[ ! -s "$MIGRATION_BACKUP_DIR/legacy-state.tar.gz" ]]; then
+    echo "❌ Pre-migration backup failed or produced an empty archive. Migration aborted; the legacy installation was left untouched."
+    return 1
+  fi
+
+  if [[ -f "$SYSTEMD_FILE" ]]; then
+    cp -p "$SYSTEMD_FILE" "$MIGRATION_BACKUP_DIR/retroiptvguide.service.bak" 2>/dev/null || true
+  fi
+
+  echo "✅ Pre-migration backup saved to $MIGRATION_BACKUP_DIR"
+  echo "   Rollback: tar -xzp -f $MIGRATION_BACKUP_DIR/legacy-state.tar.gz -C /"
+}
+
+# ---------------------------------------------------------------------------
+# _validate_migration — verify the target layout contains the essentials that
+# were present in the legacy tree before marking the migration complete.
+# ---------------------------------------------------------------------------
+_validate_migration(){
+  local errors=0
+
+  [[ -d "$STATE_DIR" ]] || { echo "❌ Validation: $STATE_DIR missing."; (( errors++ )) || true; }
+  [[ -f "$APP_DIR/app.py" ]] || { echo "❌ Validation: $APP_DIR/app.py missing."; (( errors++ )) || true; }
+  [[ -f "$APP_DIR/requirements.txt" ]] || { echo "❌ Validation: $APP_DIR/requirements.txt missing."; (( errors++ )) || true; }
+  [[ -x "$APP_DIR/venv/bin/python3" || -x "$APP_DIR/venv/bin/python" ]] || \
+    { echo "❌ Validation: no Python executable found under $APP_DIR/venv/bin/."; (( errors++ )) || true; }
+  [[ -f "$ENV_FILE" ]] || { echo "❌ Validation: $ENV_FILE missing."; (( errors++ )) || true; }
+
+  # If a legacy DB existed, verify it landed in STATE_DIR.
+  local legacy_db="$LEGACY_CONFIG_DIR/users.db"
+  if [[ -f "$legacy_db" ]]; then
+    [[ -f "$STATE_DIR/users.db" ]] || \
+      { echo "❌ Validation: legacy users.db was not copied to $STATE_DIR/users.db."; (( errors++ )) || true; }
+  fi
+
+  legacy_db="$LEGACY_CONFIG_DIR/tuners.db"
+  if [[ -f "$legacy_db" ]]; then
+    [[ -f "$STATE_DIR/tuners.db" ]] || \
+      { echo "❌ Validation: legacy tuners.db was not copied to $STATE_DIR/tuners.db."; (( errors++ )) || true; }
+  fi
+
+  if [[ -f "$MIGRATION_EXPECTED_STATE_MANIFEST" ]]; then
+    while IFS= read -r rel_path; do
+      local expected_path preserved_conflict_path
+      [[ -n "$rel_path" ]] || continue
+      expected_path="$STATE_DIR/$rel_path"
+      preserved_conflict_path="$MIGRATION_CONFLICT_DIR/$rel_path"
+      if [[ ! -e "$expected_path" && ! -e "$preserved_conflict_path" ]]; then
+        echo "❌ Validation: expected migrated state '$rel_path' is missing from $STATE_DIR and no preserved conflict copy was found."
+        (( errors++ )) || true
+      fi
+    done < "$MIGRATION_EXPECTED_STATE_MANIFEST"
+  fi
+
+  if [[ "$errors" -gt 0 ]]; then
+    echo "Migration validation found $errors error(s). Aborting."
+    echo "Restore the backup with:"
+    echo "  tar -xzp -f $MIGRATION_BACKUP_DIR/legacy-state.tar.gz -C /"
+    return 1
+  fi
+
+  echo "✅ Migration validation passed."
+}
+
+migrate_legacy_state_if_present(){
+  local migrated=false mapping legacy_source target_dir
+  require_command rsync
+
+  # Idempotency: skip if the migration marker already exists and is current.
+  if migration_marker_is_valid; then
+    echo "Migration marker found ($MIGRATION_MARKER). Skipping legacy state migration."
+    return
+  elif [[ -f "$MIGRATION_MARKER" ]]; then
+    echo "⚠️  Ignoring invalid migration marker at $MIGRATION_MARKER and retrying the legacy migration."
+    rm -f "$MIGRATION_MARKER"
+  fi
+
+  # Detect whether any legacy source paths are present.
+  if [[ ! -d "$LEGACY_CONFIG_DIR" && ! -d "$LEGACY_RUNTIME_DIR" && ! -d "$LEGACY_LOG_DIR" && \
+        ! -d "$LEGACY_AUDIO_UPLOAD_DIR" && ! -d "$LEGACY_LOGO_UPLOAD_DIR" && \
+        ! -d "$LEGACY_ROADS_CACHE_DIR" && ! -d "$LEGACY_BASEMAP_CACHE_DIR" ]]; then
+    return
+  fi
+
+  MIGRATION_DETECTED=true
+  echo "Legacy installation detected under $LEGACY_APP_DIR. Starting migration..."
+
+  # Stop only the retroiptvguide service before touching files.
+  echo "Stopping $SERVICE_NAME before migration..."
+  systemctl stop "$SERVICE_NAME" 2>/dev/null || true
+
+  # Backup everything before making any changes.
+  _migration_backup
+  preserve_legacy_directory_conflicts "$LEGACY_CONFIG_DIR" "$STATE_DIR" ""
+  preserve_legacy_directory_conflicts "$LEGACY_RUNTIME_DIR" "$STATE_DIR/runtime" "runtime"
+  preserve_legacy_directory_conflicts "$LEGACY_AUDIO_UPLOAD_DIR" "$AUDIO_UPLOAD_DIR" "uploads/audio"
+  preserve_legacy_directory_conflicts "$LEGACY_LOGO_UPLOAD_DIR" "$LOGO_UPLOAD_DIR" "uploads/logos/virtual"
+  preserve_legacy_directory_conflicts "$LEGACY_ROADS_CACHE_DIR" "$ROADS_CACHE_DIR" "cache/roads"
+  preserve_legacy_directory_conflicts "$LEGACY_BASEMAP_CACHE_DIR" "$BASEMAP_CACHE_DIR" "cache/traffic_demo"
+
+  if [[ -d "$LEGACY_CONFIG_DIR" ]]; then
+    echo "Migrating legacy state from $LEGACY_CONFIG_DIR to $STATE_DIR ..."
+    rsync -a --ignore-existing "$LEGACY_CONFIG_DIR/" "$STATE_DIR/"
+    migrated=true
+  fi
+
+  if [[ -d "$LEGACY_RUNTIME_DIR" ]]; then
+    echo "Migrating legacy runtime files from $LEGACY_RUNTIME_DIR to $STATE_DIR/runtime ..."
+    install -d -m 750 -o "$APP_USER" -g "$APP_USER" "$STATE_DIR/runtime"
+    rsync -a --ignore-existing "$LEGACY_RUNTIME_DIR/" "$STATE_DIR/runtime/"
+    migrated=true
+  fi
+
+  if [[ -d "$LEGACY_LOG_DIR" ]]; then
+    echo "Migrating legacy logs from $LEGACY_LOG_DIR to $LOG_DIR_LINUX ..."
+    rsync -a --ignore-existing "$LEGACY_LOG_DIR/" "$LOG_DIR_LINUX/"
+    migrated=true
+  fi
+
+  for mapping in \
+    "$LEGACY_AUDIO_UPLOAD_DIR:$AUDIO_UPLOAD_DIR" \
+    "$LEGACY_LOGO_UPLOAD_DIR:$LOGO_UPLOAD_DIR" \
+    "$LEGACY_ROADS_CACHE_DIR:$ROADS_CACHE_DIR" \
+    "$LEGACY_BASEMAP_CACHE_DIR:$BASEMAP_CACHE_DIR"; do
+    legacy_source="${mapping%%:*}"
+    target_dir="${mapping#*:}"
+    if [[ -d "$legacy_source" ]]; then
+      echo "Migrating legacy mutable files from $legacy_source to $target_dir ..."
+      if [[ "$legacy_source" == "$LEGACY_LOGO_UPLOAD_DIR" ]]; then
+        rsync -a --ignore-existing --exclude 'icon_pack/' "$legacy_source/" "$target_dir/"
+      else
+        rsync -a --ignore-existing "$legacy_source/" "$target_dir/"
+      fi
+      migrated=true
+    fi
+  done
+
+  if [[ "$migrated" == true ]]; then
+   chown -R "$APP_USER":"$APP_USER" "$STATE_DIR"
+  fi
 }
 
 clone_or_stage_project(){
   # Resolve the directory that contains this script
   SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+  require_command rsync
 
-  mkdir -p "$APP_DIR"; chown -R "$APP_USER":"$APP_USER" "$APP_DIR"
+  install -d -m 755 -o root -g root "$APP_DIR"
 
   # If the full release is already present locally (ZIP download or git clone),
   # use those files directly instead of cloning from GitHub.
@@ -135,9 +417,10 @@ clone_or_stage_project(){
     # Only rsync if source and destination differ; syncing a directory to itself
     # with --delete would erroneously remove files.
     if [[ "$(realpath "$SCRIPT_DIR")" != "$(realpath "$APP_DIR")" ]]; then
-      rsync -a --delete --exclude 'venv' "$SCRIPT_DIR/" "$APP_DIR/"
+      rsync -a --delete --exclude 'venv' --exclude 'config' --exclude 'runtime' --exclude '*.log' "$SCRIPT_DIR/" "$APP_DIR/"
     fi
-    chown -R "$APP_USER":"$APP_USER" "$APP_DIR"
+    chown -R root:root "$APP_DIR"
+    link_mutable_state_dirs
     chmod 744 "$APP_DIR/retroiptv_linux.sh" "$APP_DIR/retroiptv_rpi.sh" 2>/dev/null || true
     return
   fi
@@ -159,26 +442,76 @@ clone_or_stage_project(){
 
   TMP="/tmp/retroiptvguide"; rm -rf "$TMP"
   git clone --depth 1 -b main https://github.com/thehack904/RetroIPTVGuide.git "$TMP"
-  rsync -a --delete --exclude 'venv' "$TMP/" "$APP_DIR/"
-  chown -R "$APP_USER":"$APP_USER" "$APP_DIR"
+  rsync -a --delete --exclude 'venv' --exclude 'config' --exclude 'runtime' --exclude '*.log' "$TMP/" "$APP_DIR/"
+  chown -R root:root "$APP_DIR"
+  link_mutable_state_dirs
   chmod 744 "$APP_DIR/retroiptv_linux.sh" "$APP_DIR/retroiptv_rpi.sh" 2>/dev/null || true
+}
+
+link_mutable_state_dirs(){
+  local app_path state_path mapping
+  local legacy_loose_logo_dir="$APP_DIR/static/logos/virtual"
+  local mutable_paths=(
+    "$APP_DIR/static/audio:$AUDIO_UPLOAD_DIR"
+    "$APP_DIR/static/logos/virtual/uploads:$LOGO_UPLOAD_DIR"
+    "$APP_DIR/data/roads_cache:$ROADS_CACHE_DIR"
+    "$APP_DIR/static/maps/traffic_demo:$BASEMAP_CACHE_DIR"
+  )
+
+  if [[ -d "$legacy_loose_logo_dir" && ! -L "$legacy_loose_logo_dir" ]]; then
+    rsync -a --ignore-existing --exclude 'icon_pack/' --exclude 'uploads/' \
+      "$legacy_loose_logo_dir/" "$LOGO_UPLOAD_DIR/"
+  fi
+
+  for mapping in "${mutable_paths[@]}"; do
+    app_path="${mapping%%:*}"
+    state_path="${mapping#*:}"
+    [[ -n "$APP_DIR" && "$app_path" == "$APP_DIR/"* ]] || {
+      echo "Refusing to replace mutable path outside $APP_DIR: $app_path"
+      exit 1
+    }
+    install -d -m 750 -o "$APP_USER" -g "$APP_USER" "$state_path"
+    if [[ -d "$app_path" && ! -L "$app_path" ]]; then
+      rsync -a --ignore-existing "$app_path/" "$state_path/"
+    fi
+    rm -rf -- "$app_path"
+    install -d -m 755 -o root -g root "$(dirname "$app_path")"
+    ln -s "$state_path" "$app_path"
+  done
 }
 
 make_venv_and_install(){
   echo "Setting up virtualenv..."
   # Fedora/RHEL may need ensurepip to activate venv properly; Debian doesn't
   if [[ ! "$DISTRO_ID" =~ (debian|ubuntu|raspbian) ]]; then
-    sudo -u "$APP_USER" python3 -m ensurepip --upgrade 2>/dev/null || true
+    python3 -m ensurepip --upgrade 2>/dev/null || true
   fi
-  sudo -u "$APP_USER" python3 -m venv "$APP_DIR/venv" || \
-    { sudo -u "$APP_USER" python3 -m pip install --user virtualenv; sudo -u "$APP_USER" "$APP_HOME/.local/bin/virtualenv" "$APP_DIR/venv"; }
-  sudo -u "$APP_USER" "$APP_DIR/venv/bin/pip" install --upgrade pip
-  sudo -u "$APP_USER" "$APP_DIR/venv/bin/pip" install -r "$APP_DIR/requirements.txt"
+  create_virtualenv
+  "$APP_DIR/venv/bin/pip" install --upgrade pip
+  "$APP_DIR/venv/bin/pip" install -r "$APP_DIR/requirements.txt"
+  chown -R root:root "$APP_DIR"
+}
+
+create_virtualenv(){
+  if ! python3 -m venv "$APP_DIR/venv"; then
+    if command -v virtualenv >/dev/null 2>&1; then
+      virtualenv "$APP_DIR/venv" || { echo "virtualenv failed to create $APP_DIR/venv."; exit 1; }
+    elif python3 -m virtualenv --version >/dev/null 2>&1; then
+      python3 -m virtualenv "$APP_DIR/venv" || { echo "python3 -m virtualenv failed to create $APP_DIR/venv."; exit 1; }
+    else
+      echo "python3 -m venv failed and no virtualenv fallback is installed. Install python3-virtualenv and re-run this script."
+      exit 1
+    fi
+  fi
 }
 
 write_systemd_service(){
   echo "Creating systemd service..."
   local PYEXEC="$APP_DIR/venv/bin/python"; [[ -x "$APP_DIR/venv/bin/python3" ]] && PYEXEC="$APP_DIR/venv/bin/python3"
+  if [[ -f "$SYSTEMD_FILE" ]] && ! service_unit_belongs_to_retroiptvguide "$SYSTEMD_FILE"; then
+    echo "Refusing to overwrite existing systemd unit $SYSTEMD_FILE because it could not be verified as RetroIPTVGuide."
+    exit 1
+  fi
   cat >"$SYSTEMD_FILE"<<EOF
 [Unit]
 Description=IPTV Flask Server (RetroIPTVGuide)
@@ -188,6 +521,12 @@ After=network.target
 User=$APP_USER
 Group=$APP_USER
 WorkingDirectory=$APP_DIR
+Environment=RETROIPTV_DATA_DIR=$STATE_DIR
+Environment=PYTHONPYCACHEPREFIX=$PYCACHE_DIR
+EnvironmentFile=-$ENV_FILE
+RuntimeDirectory=$SERVICE_NAME
+ProtectSystem=strict
+ReadWritePaths=$STATE_DIR
 ExecStart=$PYEXEC app.py
 Restart=always
 
@@ -196,49 +535,28 @@ WantedBy=multi-user.target
 EOF
 }
 
-# Returns 0 (true) if RetroStation MC — or any other non-RetroIPTVGuide service
-# that runs as the shared 'iptv' user — is detected on this system.
-# Checks in three ways:
-#   1. Known RetroStation MC systemd service names
-#   2. Any systemd unit file that sets User=iptv but is not owned by us
-#   3. Known RetroStation MC install directories under /home/iptv
-retrostation_mc_is_present(){
-  # 1. Known service names
-  local rsmc_services=("retrostation-mc" "retrostation_mc" "retrostationmc" "retrostation")
-  for svc in "${rsmc_services[@]}"; do
-    [[ -f "/etc/systemd/system/${svc}.service" ]] && return 0
-  done
-
-  # 2. Any foreign service file that runs as the iptv user
-  local our_names=("$SERVICE_NAME" "$LEGACY_SERVICE_NAME")
-  while IFS= read -r -d '' svcfile; do
-    local svcname
-    svcname=$(basename "$svcfile" .service)
-    local is_ours=false
-    for ours in "${our_names[@]}"; do [[ "$svcname" == "$ours" ]] && is_ours=true && break; done
-    if [[ "$is_ours" == false ]] && grep -Eq '^[[:space:]]*User=iptv[[:space:]]*$' "$svcfile" 2>/dev/null; then
-      return 0
-    fi
-  done < <(find /etc/systemd/system -maxdepth 1 -name "*.service" -print0 2>/dev/null)
-
-  # 3. Known RetroStation MC directories
-  local rsmc_dirs=(
-    "/home/iptv/RetroStationMC"
-    "/home/iptv/retrostation-mc"
-    "/home/iptv/retrostation_mc"
-    "/home/iptv/retrostation"
-  )
-  for dir in "${rsmc_dirs[@]}"; do [[ -d "$dir" ]] && return 0; done
-
-  return 1
-}
-
 service_unit_belongs_to_retroiptvguide(){
   local unit_file="$1"
   [[ -f "$unit_file" ]] || return 1
   grep -Fq "RetroIPTVGuide" "$unit_file" || \
     grep -Eq '^[[:space:]]*WorkingDirectory=(/home/iptv/iptv-server|/opt/retroiptvguide)[[:space:]]*$' "$unit_file" || \
     grep -Eq '^[[:space:]]*ExecStart=(/home/iptv/iptv-server|/opt/retroiptvguide)/venv/bin/(python|python3)([[:space:]]+-[^[:space:]]+)*[[:space:]]+app\.py([[:space:]].*)?$' "$unit_file"
+}
+
+remove_unit_file_if_verified(){
+  local unit_name="$1"
+  local unit_file="$2"
+
+  [[ -f "$unit_file" ]] || return 1
+  if service_unit_belongs_to_retroiptvguide "$unit_file"; then
+    rm -f "$unit_file"
+    systemctl daemon-reload
+    echo "Removed verified systemd unit: ${unit_name}.service"
+    return 0
+  fi
+
+  echo "⚠️  Skipping unit removal for ${unit_name}.service because ownership could not be verified."
+  return 1
 }
 
 cleanup_legacy_service_if_owned(){
@@ -255,6 +573,94 @@ cleanup_legacy_service_if_owned(){
   fi
 }
 
+# Returns 0 (true) if any service other than retroiptvguide is still using the
+# legacy 'iptv' user or known RetroStation MC directories, meaning we must not
+# delete the shared home directory tree.
+legacy_iptv_dir_is_shared(){
+  local rsmc_services=("retrostation-mc" "retrostation_mc" "retrostationmc" "retrostation")
+  for svc in "${rsmc_services[@]}"; do
+    [[ -f "/etc/systemd/system/${svc}.service" ]] && return 0
+  done
+
+  while IFS= read -r -d '' svcfile; do
+    local svcname
+    svcname=$(basename "$svcfile" .service)
+    if [[ "$svcname" != "retroiptvguide" && "$svcname" != "$LEGACY_SERVICE_NAME" ]]; then
+      grep -Eq '^[[:space:]]*User=iptv[[:space:]]*$' "$svcfile" 2>/dev/null && return 0
+    fi
+  done < <(find /etc/systemd/system -maxdepth 1 -name "*.service" -print0 2>/dev/null)
+
+  local rsmc_dirs=(
+    "$LEGACY_APP_HOME/RetroStationMC"
+    "$LEGACY_APP_HOME/retrostation-mc"
+    "$LEGACY_APP_HOME/retrostation_mc"
+    "$LEGACY_APP_HOME/retrostation"
+  )
+  for dir in "${rsmc_dirs[@]}"; do [[ -d "$dir" ]] && return 0; done
+
+  return 1
+}
+
+# Remove the legacy app dir and legacy log dir after state has been migrated,
+# but only when no other service is sharing the 'iptv' user/home.
+cleanup_legacy_app_dir_if_unshared(){
+  [[ -d "$LEGACY_APP_DIR" ]] || return 0
+
+  if legacy_iptv_dir_is_shared; then
+    echo "⚠️  Another service is using the '$LEGACY_APP_USER' account — retaining $LEGACY_APP_DIR."
+  else
+    echo "Removing legacy app directory $LEGACY_APP_DIR (state already migrated)..."
+    rm -rf "$LEGACY_APP_DIR"
+    [[ -d "$LEGACY_LOG_DIR" ]] && { echo "Removing legacy log directory $LEGACY_LOG_DIR ..."; rm -rf "$LEGACY_LOG_DIR"; }
+    echo "✅ Legacy directories removed."
+  fi
+}
+
+safe_to_remove_dedicated_user(){
+  local passwd_entry user_home remaining_owned_file
+  passwd_entry=$(getent passwd "$APP_USER" 2>/dev/null || true)
+  [[ -n "$passwd_entry" ]] || return 1
+
+  user_home=$(printf '%s' "$passwd_entry" | cut -d: -f6)
+  if [[ "$user_home" != "$APP_HOME" && "$user_home" != "$STATE_DIR" ]]; then
+    echo "⚠️  Refusing to remove user '$APP_USER': unexpected home path '$user_home'."
+    return 1
+  fi
+
+  if pgrep -u "$APP_USER" >/dev/null 2>&1; then
+    echo "⚠️  Refusing to remove user '$APP_USER': active processes still running."
+    return 1
+  fi
+
+  remaining_owned_file=$(find /opt /etc /var/lib /var/log /run /tmp -xdev -user "$APP_USER" -print -quit 2>/dev/null || true)
+  if [[ -n "$remaining_owned_file" ]]; then
+    echo "⚠️  Refusing to remove user '$APP_USER': files still owned by this account exist (e.g. $remaining_owned_file)."
+    return 1
+  fi
+
+  return 0
+}
+
+print_cleanup_summary(){
+  local title="$1"
+  local removed_paths="$2"
+  local retained_paths="$3"
+  local warnings="$4"
+
+  echo ""
+  echo "============================================================"
+  echo " $title "
+  echo "============================================================"
+  echo "Removed paths/resources:"
+  [[ -n "$removed_paths" ]] && printf '%s\n' "$removed_paths" || echo "  (none)"
+  echo "Retained paths/resources:"
+  [[ -n "$retained_paths" ]] && printf '%s\n' "$retained_paths" || echo "  (none)"
+  if [[ -n "$warnings" ]]; then
+    echo "Warnings:"
+    printf '%s\n' "$warnings"
+  fi
+}
+
 rhel_firewall_selinux(){
   [[ "$PKG_MANAGER" =~ dnf|yum ]] || return 0
   if systemctl is-active --quiet firewalld; then
@@ -263,6 +669,28 @@ rhel_firewall_selinux(){
   fi
   if command -v semanage >/dev/null 2>&1; then
     semanage port -a -t http_port_t -p tcp 5000 2>/dev/null || semanage port -m -t http_port_t -p tcp 5000
+  fi
+}
+
+revert_firewall_selinux(){
+  echo "Reverting firewall and SELinux changes (if applicable)..."
+
+  if command -v firewall-cmd >/dev/null 2>&1 && systemctl is-active --quiet firewalld; then
+    echo " - Removing TCP port 5000 rule from firewalld"
+    firewall-cmd --permanent --remove-port=5000/tcp 2>/dev/null || true
+    firewall-cmd --reload 2>/dev/null || true
+  fi
+
+  if command -v ufw >/dev/null 2>&1; then
+    if ufw status | grep -q "5000/tcp"; then
+      echo " - Removing TCP port 5000 rule from UFW"
+      ufw delete allow 5000/tcp >/dev/null 2>&1 || true
+    fi
+  fi
+
+  if command -v semanage >/dev/null 2>&1; then
+    echo " - Removing SELinux http_port_t mapping for TCP/5000"
+    semanage port -d -t http_port_t -p tcp 5000 2>/dev/null || true
   fi
 }
 
@@ -279,10 +707,14 @@ start_and_verify(){
 
 install_linux(){
   agree_terms
-  ensure_packages; ensure_user; clone_or_stage_project; make_venv_and_install; write_systemd_service
-  cleanup_legacy_service_if_owned
+  ensure_packages; ensure_user; ensure_layout_dirs; migrate_legacy_state_if_present; clone_or_stage_project
+  make_venv_and_install; write_environment_file; write_systemd_service; _validate_migration
+  [[ "$MIGRATION_DETECTED" == true ]] && write_migration_marker
   rhel_firewall_selinux; start_and_verify
+  cleanup_legacy_installation_if_migration_complete
   echo "Installed to: $APP_DIR"
+  echo "Configuration directory: $CONFIG_DIR"
+  echo "State directory: $STATE_DIR"
   echo "End time: $(date)"
   echo "Access at: http://$(hostname -I | awk '{print $1}'):5000"
   echo "Default login: admin / strongpassword123"
@@ -292,107 +724,193 @@ install_linux(){
 
 update_linux(){
   echo "Updating app..."
-  sudo -u "$APP_USER" bash -c "cd '$APP_DIR' && git fetch --all && git reset --hard origin/main"
+  ensure_user; ensure_layout_dirs
+  migrate_legacy_state_if_present
+  if [[ -d "$APP_DIR/.git" ]]; then
+    chown -R root:root "$APP_DIR"
+    bash -c "cd '$APP_DIR' && git fetch --all && git reset --hard origin/main"
+    link_mutable_state_dirs
+  else
+    clone_or_stage_project
+  fi
+  write_environment_file
   echo "Updating Python dependencies..."
   if [[ -d "$APP_DIR/venv" ]]; then
-    sudo -u "$APP_USER" "$APP_DIR/venv/bin/pip" install --upgrade pip
-    sudo -u "$APP_USER" "$APP_DIR/venv/bin/pip" install -r "$APP_DIR/requirements.txt"
+    :
   else
     echo "⚠️  No venv found -- recreating..."
-    sudo -u "$APP_USER" python3 -m venv "$APP_DIR/venv"
-    sudo -u "$APP_USER" "$APP_DIR/venv/bin/pip" install --upgrade pip
-    sudo -u "$APP_USER" "$APP_DIR/venv/bin/pip" install -r "$APP_DIR/requirements.txt"
+    create_virtualenv
   fi
+  "$APP_DIR/venv/bin/pip" install --upgrade pip
+  "$APP_DIR/venv/bin/pip" install -r "$APP_DIR/requirements.txt"
+  chown -R root:root "$APP_DIR"
   write_systemd_service
-  cleanup_legacy_service_if_owned
-  systemctl daemon-reload; systemctl restart "$SERVICE_NAME"
+  _validate_migration
+  [[ "$MIGRATION_DETECTED" == true ]] && write_migration_marker
+  systemctl daemon-reload; systemctl enable "$SERVICE_NAME"; systemctl restart "$SERVICE_NAME"
+  cleanup_legacy_installation_if_migration_complete
   echo "✅ Updated and restarted."
 }
 
 uninstall_linux(){
+  local removed_summary="" retained_summary="" warning_summary=""
+  local modern_resources_present=false legacy_only_resources_present=false
+
+  [[ -d "$APP_DIR" || -f "$SYSTEMD_FILE" ]] && modern_resources_present=true
+  [[ "$modern_resources_present" == false && ( -d "$LEGACY_APP_DIR" || -f "$LEGACY_SYSTEMD_FILE" ) ]] && legacy_only_resources_present=true
+
   echo "Stopping and disabling service..."
   systemctl stop "$SERVICE_NAME" 2>/dev/null || true
   systemctl disable "$SERVICE_NAME" 2>/dev/null || true
-  [[ -f "$SYSTEMD_FILE" ]] && rm -f "$SYSTEMD_FILE" && systemctl daemon-reload
-  cleanup_legacy_service_if_owned
+  if remove_unit_file_if_verified "$SERVICE_NAME" "$SYSTEMD_FILE"; then
+    removed_summary+="  - $SYSTEMD_FILE"$'\n'
+  elif [[ -f "$SYSTEMD_FILE" ]]; then
+    retained_summary+="  - $SYSTEMD_FILE"$'\n'
+    warning_summary+="  - Could not verify ownership of $SYSTEMD_FILE; left untouched."$'\n'
+  fi
 
   echo "Removing files..."
-  rm -rf "$LOG_DIR_LINUX" 2>/dev/null || true
-  [[ -d "/opt/retroiptvguide" ]] && { echo "Removing /opt/retroiptvguide ..."; rm -rf /opt/retroiptvguide; }
-  [[ -d "$APP_HOME/iptv-server" ]] && { echo "Removing $APP_HOME/iptv-server ..."; rm -rf "$APP_HOME/iptv-server"; }
-
-  echo "Reverting firewall and SELinux changes (if applicable)..."
-
-  # --- Firewalld ---
-  if command -v firewall-cmd >/dev/null 2>&1 && systemctl is-active --quiet firewalld; then
-    echo " - Removing TCP port 5000 rule from firewalld"
-    firewall-cmd --permanent --remove-port=5000/tcp 2>/dev/null || true
-    firewall-cmd --reload 2>/dev/null || true
+  if [[ -d "$APP_DIR" ]]; then
+    echo "Removing $APP_DIR ..."
+    rm -rf "$APP_DIR"
+    removed_summary+="  - $APP_DIR"$'\n'
+  fi
+  if [[ -d "$RUNTIME_DIR" ]]; then
+    echo "Removing runtime directory $RUNTIME_DIR ..."
+    rm -rf "$RUNTIME_DIR"
+    removed_summary+="  - $RUNTIME_DIR"$'\n'
+  fi
+  if [[ -d "$STAGING_TMP_DIR" ]]; then
+    echo "Removing staging directory $STAGING_TMP_DIR ..."
+    rm -rf "$STAGING_TMP_DIR"
+    removed_summary+="  - $STAGING_TMP_DIR"$'\n'
   fi
 
-  # --- UFW ---
-  if command -v ufw >/dev/null 2>&1; then
-    if ufw status | grep -q "5000/tcp"; then
-      echo " - Removing TCP port 5000 rule from UFW"
-      ufw delete allow 5000/tcp >/dev/null 2>&1 || true
-    fi
-  fi
-
-  # --- SELinux ---
-  if command -v semanage >/dev/null 2>&1; then
-    echo " - Removing SELinux http_port_t mapping for TCP/5000"
-    semanage port -d -t http_port_t -p tcp 5000 2>/dev/null || true
-  fi
-
-  echo "Checking for shared-user services (e.g. RetroStation MC)..."
-  if retrostation_mc_is_present; then
-    echo ""
-    echo "⚠️  RetroStation MC (or another service using the 'iptv' user) was detected."
-    echo "   Skipping removal of user '$APP_USER', group '$APP_USER', and home directory"
-    echo "   to avoid breaking that installation."
-    echo "   To fully remove the 'iptv' user, uninstall RetroStation MC first, then run:"
-    echo "     pkill -u $APP_USER 2>/dev/null || true"
-    echo "     userdel -r $APP_USER && groupdel $APP_USER"
-    SHARED_USER_PRESERVED=true
-  else
-    echo "Removing user/group..."
-
-    # Stop processes that may still run as iptv
-    pkill -u "$APP_USER" 2>/dev/null || true
-
-    # Remove system user and home directory if it exists
-    if id "$APP_USER" &>/dev/null; then
-      echo " - Deleting user '$APP_USER' and home directory"
-      userdel -r "$APP_USER" 2>/dev/null || true
-    else
-      echo " - User '$APP_USER' not found, skipping"
+  if [[ "$legacy_only_resources_present" == true ]]; then
+    if remove_unit_file_if_verified "$LEGACY_SERVICE_NAME" "$LEGACY_SYSTEMD_FILE"; then
+      removed_summary+="  - $LEGACY_SYSTEMD_FILE"$'\n'
+    elif [[ -f "$LEGACY_SYSTEMD_FILE" ]]; then
+      retained_summary+="  - $LEGACY_SYSTEMD_FILE"$'\n'
+      warning_summary+="  - Could not verify ownership of $LEGACY_SYSTEMD_FILE; left untouched."$'\n'
     fi
 
-    # Remove group if it still exists
-    if getent group "$APP_USER" >/dev/null 2>&1; then
-      echo " - Deleting group '$APP_USER'"
-      groupdel "$APP_USER" 2>/dev/null || true
+    if [[ -d "$LEGACY_APP_DIR" ]]; then
+      echo "Removing legacy project directory $LEGACY_APP_DIR ..."
+      rm -rf "$LEGACY_APP_DIR"
+      removed_summary+="  - $LEGACY_APP_DIR"$'\n'
     fi
-
-    SHARED_USER_PRESERVED=false
+    warning_summary+="  - Legacy shared user/group/home resources were not deleted automatically; review $LEGACY_APP_HOME manually."$'\n'
+  elif [[ -d "$LEGACY_APP_DIR" || -f "$LEGACY_SYSTEMD_FILE" ]]; then
+    [[ -d "$LEGACY_APP_DIR" ]] && retained_summary+="  - $LEGACY_APP_DIR"$'\n'
+    [[ -f "$LEGACY_SYSTEMD_FILE" ]] && retained_summary+="  - $LEGACY_SYSTEMD_FILE"$'\n'
   fi
 
-  echo ""
-  echo "============================================================"
-  echo " Uninstallation Complete "
-  echo "============================================================"
-  echo "Removed:"
-  echo "  - RetroIPTVGuide systemd service and unit file"
-  echo "  - Application directories (/opt/retroiptvguide or /home/iptv/iptv-server)"
-  echo "  - Firewall rules (firewalld/UFW) for TCP 5000"
-  echo "  - SELinux port context (if previously set)"
-  if [[ "${SHARED_USER_PRESERVED:-false}" == true ]]; then
-    echo "  - (User/group 'iptv' and home directory preserved — RetroStation MC detected)"
-  else
-    echo "  - User and group 'iptv'"
-  fi
-  echo ""
+  revert_firewall_selinux
+  removed_summary+="  - firewall/SELinux TCP 5000 allowances (if present)"$'\n'
+
+  [[ -d "$CONFIG_DIR" ]] && retained_summary+="  - $CONFIG_DIR"$'\n'
+  [[ -d "$STATE_DIR" ]] && retained_summary+="  - $STATE_DIR"$'\n'
+  retained_summary+="  - user/group: $APP_USER"$'\n'
+  [[ -d "$LEGACY_APP_HOME" ]] && retained_summary+="  - $LEGACY_APP_HOME"$'\n'
+  [[ -d "$LEGACY_LOG_DIR" ]] && retained_summary+="  - $LEGACY_LOG_DIR"$'\n'
+
+  print_cleanup_summary "Uninstallation Complete" "$removed_summary" "$retained_summary" "$warning_summary"
   echo "✅ Uninstall complete. Full log saved to $LOGFILE."
+}
+
+purge_linux(){
+  local removed_summary="" retained_summary="" warning_summary=""
+  local modern_resources_present=false legacy_resources_present=false
+  local app_group_pre_exists=false
+
+  [[ -d "$APP_DIR" || -f "$SYSTEMD_FILE" ]] && modern_resources_present=true
+  [[ -d "$LEGACY_APP_DIR" || -f "$LEGACY_SYSTEMD_FILE" ]] && legacy_resources_present=true
+
+  echo "Stopping and disabling service..."
+  systemctl stop "$SERVICE_NAME" 2>/dev/null || true
+  systemctl disable "$SERVICE_NAME" 2>/dev/null || true
+  if remove_unit_file_if_verified "$SERVICE_NAME" "$SYSTEMD_FILE"; then
+    removed_summary+="  - $SYSTEMD_FILE"$'\n'
+  elif [[ -f "$SYSTEMD_FILE" ]]; then
+    retained_summary+="  - $SYSTEMD_FILE"$'\n'
+    warning_summary+="  - Could not verify ownership of $SYSTEMD_FILE; left untouched."$'\n'
+  fi
+  revert_firewall_selinux
+  removed_summary+="  - firewall/SELinux TCP 5000 allowances (if present)"$'\n'
+
+  echo "Purging persisted configuration and state..."
+  if [[ -d "$CONFIG_DIR" ]]; then
+    echo "Removing $CONFIG_DIR ..."
+    rm -rf "$CONFIG_DIR"
+    removed_summary+="  - $CONFIG_DIR"$'\n'
+  fi
+  if [[ -d "$STATE_DIR" ]]; then
+    echo "Removing $STATE_DIR ..."
+    rm -rf "$STATE_DIR"
+    removed_summary+="  - $STATE_DIR"$'\n'
+  fi
+  if [[ -d "$APP_DIR" ]]; then
+    echo "Removing $APP_DIR ..."
+    rm -rf "$APP_DIR"
+    removed_summary+="  - $APP_DIR"$'\n'
+  fi
+  if [[ -d "$RUNTIME_DIR" ]]; then
+    echo "Removing runtime directory $RUNTIME_DIR ..."
+    rm -rf "$RUNTIME_DIR"
+    removed_summary+="  - $RUNTIME_DIR"$'\n'
+  fi
+  if [[ -d "$STAGING_TMP_DIR" ]]; then
+    echo "Removing staging directory $STAGING_TMP_DIR ..."
+    rm -rf "$STAGING_TMP_DIR"
+    removed_summary+="  - $STAGING_TMP_DIR"$'\n'
+  fi
+
+  if [[ "$legacy_resources_present" == true ]]; then
+    if remove_unit_file_if_verified "$LEGACY_SERVICE_NAME" "$LEGACY_SYSTEMD_FILE"; then
+      removed_summary+="  - $LEGACY_SYSTEMD_FILE"$'\n'
+    elif [[ -f "$LEGACY_SYSTEMD_FILE" ]]; then
+      retained_summary+="  - $LEGACY_SYSTEMD_FILE"$'\n'
+      warning_summary+="  - Could not verify ownership of $LEGACY_SYSTEMD_FILE; left untouched."$'\n'
+    fi
+
+    if [[ -d "$LEGACY_APP_DIR" ]]; then
+      echo "Removing legacy project directory $LEGACY_APP_DIR ..."
+      rm -rf "$LEGACY_APP_DIR"
+      removed_summary+="  - $LEGACY_APP_DIR"$'\n'
+    fi
+    warning_summary+="  - Legacy shared user/group/home/log resources were not deleted automatically; review $LEGACY_APP_HOME and $LEGACY_LOG_DIR manually."$'\n'
+  fi
+
+  echo "Removing dedicated service account..."
+  getent group "$APP_USER" >/dev/null 2>&1 && app_group_pre_exists=true
+  if id "$APP_USER" &>/dev/null; then
+    if safe_to_remove_dedicated_user; then
+      userdel "$APP_USER" 2>/dev/null || true
+      removed_summary+="  - user: $APP_USER"$'\n'
+    else
+      retained_summary+="  - user: $APP_USER"$'\n'
+      warning_summary+="  - Dedicated user $APP_USER was retained because cleanup safety checks did not pass."$'\n'
+    fi
+  fi
+  if getent group "$APP_USER" >/dev/null 2>&1 && ! id "$APP_USER" >/dev/null 2>&1; then
+    groupdel "$APP_USER" 2>/dev/null || true
+    if getent group "$APP_USER" >/dev/null 2>&1; then
+      retained_summary+="  - group: $APP_USER"$'\n'
+    else
+      removed_summary+="  - group: $APP_USER"$'\n'
+    fi
+  elif getent group "$APP_USER" >/dev/null 2>&1; then
+    retained_summary+="  - group: $APP_USER"$'\n'
+  elif [[ "$app_group_pre_exists" == true ]]; then
+    removed_summary+="  - group: $APP_USER"$'\n'
+  fi
+
+  [[ -d "$LEGACY_APP_HOME" ]] && retained_summary+="  - shared user/group/home: $LEGACY_APP_USER / $LEGACY_APP_HOME"$'\n'
+  [[ -d "$LEGACY_LOG_DIR" ]] && retained_summary+="  - shared legacy logs path: $LEGACY_LOG_DIR"$'\n'
+
+  print_cleanup_summary "Purge Complete" "$removed_summary" "$retained_summary" "$warning_summary"
+  echo "Legacy shared account '$LEGACY_APP_USER' is left untouched."
+  echo "✅ Purge complete."
 }
 
 
@@ -400,6 +918,7 @@ case "$ACTION" in
   install) install_linux ;;
   update) update_linux ;;
   uninstall) uninstall_linux ;;
+  purge) purge_linux ;;
   -h|--help|help|"") usage ;;
   *) usage ;;
 esac

--- a/retroiptv_rpi.sh
+++ b/retroiptv_rpi.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-VERSION="4.9.8"
+VERSION="4.9.9"
 # RetroIPTVGuide Raspberry Pi Installer (Headless, Pi3/4/5)
 # Installs to /home/iptv/iptv-server for consistency with Debian/Windows
 # Logs to /var/log/retroiptvguide/install-YYYYMMDD-HHMMSS.log
@@ -189,7 +189,7 @@ install_app() {
     echo "✅ Full release detected in '$SCRIPT_DIR'. Using local files."
     # Only rsync if source and destination differ to avoid self-deletion.
     if [ "$(realpath "$SCRIPT_DIR")" != "$(realpath "$APP_DIR")" ]; then
-      sudo rsync -a --delete --exclude 'venv' "$SCRIPT_DIR/" "$APP_DIR/"
+      sudo rsync -a --delete --exclude 'venv' --exclude 'data' "$SCRIPT_DIR/" "$APP_DIR/"
     fi
     ensure_owned_by_iptv
     sudo chmod 744 "$APP_DIR/retroiptv_linux.sh" "$APP_DIR/retroiptv_rpi.sh" 2>/dev/null || true
@@ -357,13 +357,37 @@ update_app() {
   echo "Updating installation in $APP_DIR"
   echo ""
 
-  if [ ! -d "$APP_DIR/.git" ]; then
-    echo "❌ Cannot update — directory is not a git repo: $APP_DIR"
-    exit 1
+  if [ -d "$APP_DIR/.git" ]; then
+    echo "Pulling latest updates from git..."
+    sudo -u "$APP_USER" bash -lc "cd '$APP_DIR' && git fetch --all && git reset --hard origin/main"
+  else
+    echo "⚠️  $APP_DIR is not a git repository (installed from local files or ZIP)."
+    SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+    if [ -f "$SCRIPT_DIR/app.py" ] && [ -f "$SCRIPT_DIR/requirements.txt" ]; then
+      echo "✅ Full release detected in '$SCRIPT_DIR'. Updating from local files."
+      if [ "$(realpath "$SCRIPT_DIR")" != "$(realpath "$APP_DIR")" ]; then
+        sudo rsync -a --delete --exclude 'venv' --exclude 'data' "$SCRIPT_DIR/" "$APP_DIR/"
+        ensure_owned_by_iptv
+        sudo chmod 744 "$APP_DIR/retroiptv_linux.sh" "$APP_DIR/retroiptv_rpi.sh" 2>/dev/null || true
+      fi
+    else
+      echo ""
+      echo "ℹ️  No local release files found. The updater needs to clone from GitHub."
+      echo ""
+      if [ "$AUTO_YES" = true ]; then
+        echo "Auto-yes flag set. Proceeding with clone."
+      else
+        read -p "Proceed with cloning from GitHub? (yes/no): " clone_confirm
+        [[ "$clone_confirm" != "yes" ]] && echo "Update aborted by user." && exit 1
+      fi
+      sudo rm -rf /tmp/retroiptvguide_update
+      sudo -u "$APP_USER" git clone https://github.com/thehack904/RetroIPTVGuide.git /tmp/retroiptvguide_update
+      sudo rsync -a --delete --exclude 'venv' --exclude 'data' /tmp/retroiptvguide_update/ "$APP_DIR/"
+      sudo rm -rf /tmp/retroiptvguide_update
+      ensure_owned_by_iptv
+      sudo chmod 744 "$APP_DIR/retroiptv_linux.sh" "$APP_DIR/retroiptv_rpi.sh" 2>/dev/null || true
+    fi
   fi
-
-  echo "Pulling latest updates..."
-  sudo -u "$APP_USER" bash -lc "cd '$APP_DIR' && git fetch --all && git reset --hard origin/main"
 
   echo "Updating Python dependencies..."
   if [ -d "$APP_DIR/venv" ]; then
@@ -381,6 +405,13 @@ update_app() {
   echo "Restarting service..."
   sudo systemctl daemon-reload
   sudo systemctl restart retroiptvguide
+
+  sleep 3
+  if systemctl is-active --quiet retroiptvguide; then
+    echo "✅ Service is active."
+  else
+    echo "❌ Service failed to restart. Run: sudo systemctl status retroiptvguide"
+  fi
 
   echo ""
   echo "============================================================"

--- a/retroiptv_windows.bat
+++ b/retroiptv_windows.bat
@@ -3,7 +3,7 @@ mode con: cols=160 lines=50
 
 REM ============================================================
 REM RetroIPTVGuide Windows Unified Installer / Uninstaller
-REM Version: v4.9.8
+REM Version: v4.9.9
 REM License: Creative Commons BY-NC-SA 4.0
 REM ============================================================
 
@@ -31,7 +31,7 @@ if /i "%choice%"=="Y" (
 
 :continue
 setlocal
-set "VERSION=4.9.8"
+set "VERSION=4.9.9"
 set "REPO_URL=https://github.com/thehack904/RetroIPTVGuide.git"
 set "ZIP_URL=https://github.com/thehack904/RetroIPTVGuide/archive/refs/heads/main.zip"
 set "INSTALL_DIR=%~dp0RetroIPTVGuide"

--- a/retroiptv_windows.ps1
+++ b/retroiptv_windows.ps1
@@ -1,7 +1,7 @@
 <# 
 RetroIPTVGuide Windows Installer/Uninstaller
 Filename: retroiptv_windows.ps1
-Version: 4.9.8
+Version: 4.9.9
 
 License: Creative Commons Attribution-NonCommercial-ShareAlike 4.0 International
 https://creativecommons.org/licenses/by-nc-sa/4.0/
@@ -55,7 +55,7 @@ if (-not ([Security.Principal.WindowsPrincipal] [Security.Principal.WindowsIdent
 $ErrorActionPreference = 'Stop'
 $PSDefaultParameterValues['Out-File:Encoding'] = 'utf8'
 
-$VERSION = "4.9.8"
+$VERSION = "4.9.9"
 $ScriptDir = Split-Path -Parent -Path $MyInvocation.MyCommand.Path
 Set-Location $ScriptDir
 

--- a/tests/test_admin_diagnostics.py
+++ b/tests/test_admin_diagnostics.py
@@ -782,6 +782,7 @@ class TestHealthChecks:
         assert "data_dir" in result
         assert "logs_dir" in result
         assert "app_working_dir" in result
+        assert result["app_working_dir"]["exists"] is True
 
     def test_check_file_system_symlink_detection(self, isolated_db, tmp_path):
         """Symlink targets should be reported (critical for Docker volume debugging)."""

--- a/tests/test_install_scripts.py
+++ b/tests/test_install_scripts.py
@@ -1,23 +1,258 @@
 from pathlib import Path
 import re
+import subprocess
+import textwrap
 
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
+LINUX_INSTALLER = REPO_ROOT / "retroiptv_linux.sh"
+PYTHON_CI = REPO_ROOT / ".github" / "workflows" / "python-app.yml"
 
 
-def test_linux_installer_uses_product_specific_service_name():
-    script = (REPO_ROOT / "retroiptv_linux.sh").read_text()
+def _section(script: str, start: str, end: str) -> str:
+    return script.split(start, 1)[1].split(end, 1)[0]
 
-    assert 'SERVICE_NAME="retroiptvguide"' in script
-    assert 'LEGACY_SERVICE_NAME="iptv-server"' in script
+
+def _linux_function_block() -> str:
+    script = LINUX_INSTALLER.read_text()
+    return script[script.index("usage(){"):script.index('case "$ACTION" in')]
+
+
+def _write_fake_command(path: Path, body: str) -> None:
+    path.write_text(body)
+    path.chmod(0o755)
+
+
+def _run_linux_function_harness(tmp_path: Path, command: str, tar_mode: str = "success") -> subprocess.CompletedProcess[str]:
+    root = tmp_path / "root"
+    bin_dir = tmp_path / "bin"
+    root.mkdir()
+    bin_dir.mkdir()
+
+    rsync_script = """#!/usr/bin/env bash
+set -euo pipefail
+ignore_existing=false
+args=()
+skip_next=false
+excludes=()
+for arg in "$@"; do
+  if [[ "$skip_next" == true ]]; then
+    excludes+=("$arg")
+    skip_next=false
+    continue
+  fi
+  case "$arg" in
+    -a) ;;
+    --ignore-existing) ignore_existing=true ;;
+    --exclude) skip_next=true ;;
+    *) args+=("$arg") ;;
+  esac
+done
+src="${args[0]%/}"
+dst="${args[1]%/}"
+mkdir -p "$dst"
+if [[ -d "$src" ]]; then
+  filtered_src=$(mktemp -d)
+  cp -a "$src"/. "$filtered_src"/
+  for exclude in "${excludes[@]+${excludes[@]}}"; do
+    rm -rf "$filtered_src/${exclude%/}"
+  done
+  if [[ "$ignore_existing" == true ]]; then
+    cp -a -n "$filtered_src"/. "$dst"/
+  else
+    cp -a "$filtered_src"/. "$dst"/
+  fi
+  rm -rf "$filtered_src"
+else
+  cp -a "$src" "$dst"
+fi
+"""
+    _write_fake_command(bin_dir / "rsync", rsync_script)
+
+    if tar_mode == "success":
+        tar_script = """#!/usr/bin/env bash
+set -euo pipefail
+archive=""
+prev=""
+for arg in "$@"; do
+  if [[ "$prev" == "f" ]]; then
+    archive="$arg"
+    prev=""
+    continue
+  fi
+  [[ "$arg" == "-f" ]] && prev="f"
+done
+printf 'legacy-backup' > "$archive"
+"""
+    elif tar_mode == "empty":
+        tar_script = """#!/usr/bin/env bash
+set -euo pipefail
+archive=""
+prev=""
+for arg in "$@"; do
+  if [[ "$prev" == "f" ]]; then
+    archive="$arg"
+    prev=""
+    continue
+  fi
+  [[ "$arg" == "-f" ]] && prev="f"
+done
+: > "$archive"
+"""
+    else:
+        tar_script = "#!/usr/bin/env bash\nexit 1\n"
+    _write_fake_command(bin_dir / "tar", tar_script)
+
+    bash_script = textwrap.dedent(
+        f"""
+        set -euo pipefail
+        VERSION="4.9.9"
+        TIMESTAMP="2026-08-07_00-00-00"
+        APP_USER="retroiptvguide"
+        APP_HOME="{root}/var/lib/retroiptvguide-user"
+        APP_DIR="{root}/opt/retroiptvguide"
+        CONFIG_DIR="{root}/etc/retroiptvguide"
+        STATE_DIR="{root}/var/lib/retroiptvguide"
+        ENV_FILE="$CONFIG_DIR/retroiptvguide.env"
+        LOG_DIR_LINUX="$STATE_DIR/logs"
+        PYCACHE_DIR="$STATE_DIR/pycache"
+        RUNTIME_DIR="{root}/run/retroiptvguide"
+        STAGING_TMP_DIR="{root}/tmp/retroiptvguide"
+        SERVICE_NAME="retroiptvguide"
+        SYSTEMD_FILE="{root}/etc/systemd/system/retroiptvguide.service"
+        LEGACY_SERVICE_NAME="iptv-server"
+        LEGACY_SYSTEMD_FILE="{root}/etc/systemd/system/iptv-server.service"
+        LEGACY_APP_USER="iptv"
+        LEGACY_APP_HOME="{root}/home/iptv"
+        LEGACY_APP_DIR="$LEGACY_APP_HOME/iptv-server"
+        LEGACY_CONFIG_DIR="$LEGACY_APP_DIR/config"
+        LEGACY_RUNTIME_DIR="$LEGACY_APP_DIR/runtime"
+        LEGACY_LOG_DIR="{root}/var/log/iptv"
+        LEGACY_AUDIO_UPLOAD_DIR="$LEGACY_APP_DIR/static/audio"
+        LEGACY_LOGO_UPLOAD_DIR="$LEGACY_APP_DIR/static/logos/virtual"
+        LEGACY_ROADS_CACHE_DIR="$LEGACY_APP_DIR/data/roads_cache"
+        LEGACY_BASEMAP_CACHE_DIR="$LEGACY_APP_DIR/static/maps/traffic_demo"
+        UPLOAD_DIR="$STATE_DIR/uploads"
+        AUDIO_UPLOAD_DIR="$UPLOAD_DIR/audio"
+        LOGO_UPLOAD_DIR="$UPLOAD_DIR/logos/virtual"
+        CACHE_DIR="$STATE_DIR/cache"
+        ROADS_CACHE_DIR="$CACHE_DIR/roads"
+        BASEMAP_CACHE_DIR="$CACHE_DIR/traffic_demo"
+        PATH="{bin_dir}:$PATH"
+        mkdir -p "$APP_DIR" "$CONFIG_DIR" "$STATE_DIR" "$LOG_DIR_LINUX" "$PYCACHE_DIR" "$(dirname "$SYSTEMD_FILE")" "$LEGACY_CONFIG_DIR" "$LEGACY_RUNTIME_DIR" "$LEGACY_LOG_DIR"
+        install() {{
+          if [[ "${{1:-}}" == "-d" ]]; then
+            mkdir -p "${{@: -1}}"
+          else
+            command install "$@"
+          fi
+        }}
+        chown() {{ :; }}
+        systemctl() {{ :; }}
+        {_linux_function_block()}
+        MIGRATION_BACKUP_DIR="{root}/var/backups/retroiptvguide-migration-${{TIMESTAMP}}"
+        MIGRATION_EXPECTED_STATE_MANIFEST="$MIGRATION_BACKUP_DIR/expected-state-files.txt"
+        MIGRATION_CONFLICT_DIR="$STATE_DIR/migration-conflicts/v4.9.9-${{TIMESTAMP}}"
+        MIGRATION_CONFLICT_MANIFEST="$MIGRATION_BACKUP_DIR/conflicted-state-files.txt"
+        {command}
+        """
+    )
+    return subprocess.run(["bash", "-lc", bash_script], capture_output=True, text=True)
+
+
+def test_linux_installer_uses_dedicated_layout_and_account():
+    script = LINUX_INSTALLER.read_text()
+
+    assert 'APP_USER="retroiptvguide"' in script
+    assert 'APP_DIR="/opt/retroiptvguide"' in script
+    assert 'CONFIG_DIR="/etc/retroiptvguide"' in script
+    assert 'STATE_DIR="/var/lib/retroiptvguide"' in script
+    assert 'LEGACY_APP_DIR="$LEGACY_APP_HOME/iptv-server"' in script
 
 
 def test_linux_installer_only_cleans_legacy_service_when_owned_by_retroiptvguide():
-    script = (REPO_ROOT / "retroiptv_linux.sh").read_text()
+    script = LINUX_INSTALLER.read_text()
 
     assert "service_unit_belongs_to_retroiptvguide()" in script
     assert 'grep -Fq "RetroIPTVGuide" "$unit_file"' in script
     assert 'Leaving legacy $LEGACY_SERVICE_NAME service untouched because it is not owned by RetroIPTVGuide.' in script
+
+
+def test_linux_installer_generated_systemd_service_uses_target_layout():
+    script = LINUX_INSTALLER.read_text()
+    service_section = _section(script, "write_systemd_service(){", "service_unit_belongs_to_retroiptvguide(){")
+
+    assert "User=$APP_USER" in service_section
+    assert "Group=$APP_USER" in service_section
+    assert "WorkingDirectory=$APP_DIR" in service_section
+    assert "Environment=RETROIPTV_DATA_DIR=$STATE_DIR" in service_section
+    assert "Environment=PYTHONPYCACHEPREFIX=$PYCACHE_DIR" in service_section
+    assert "EnvironmentFile=-$ENV_FILE" in service_section
+    assert "BindPaths=" not in service_section
+    assert "RuntimeDirectory=$SERVICE_NAME" in service_section
+    assert "ProtectSystem=strict" in service_section
+    assert "ReadWritePaths=$STATE_DIR" in service_section
+    assert "$RUNTIME_DIR" not in service_section
+    assert "ExecStart=$PYEXEC app.py" in service_section
+
+
+def test_linux_installer_preserves_admin_environment_overrides():
+    script = LINUX_INSTALLER.read_text()
+    env_section = _section(script, "write_environment_file(){", "migrate_legacy_state_if_present(){")
+
+    assert 'if [[ -f "$ENV_FILE" ]]' in env_section
+    assert "grep -Eq '^RETROIPTV_DATA_DIR='" in env_section
+    assert 'sed -i "s|^RETROIPTV_DATA_DIR=.*$|RETROIPTV_DATA_DIR=$STATE_DIR|"' in env_section
+    assert "printf '\\nRETROIPTV_DATA_DIR=%s\\n' \"$STATE_DIR\" >>\"$ENV_FILE\"" in env_section
+    assert 'chown root:root "$ENV_FILE"' in env_section
+
+
+def test_linux_installer_fresh_install_does_not_fail_when_no_legacy_state_exists():
+    script = LINUX_INSTALLER.read_text()
+    migration_section = _section(script, "migrate_legacy_state_if_present(){", "clone_or_stage_project(){")
+
+    assert 'if [[ "$migrated" == true ]]; then' in migration_section
+    assert 'chown -R "$APP_USER":"$APP_USER" "$STATE_DIR"' in migration_section
+    assert '[[ "$migrated" == true ]] && chown -R "$APP_USER":"$APP_USER" "$STATE_DIR"' not in migration_section
+
+
+def test_linux_installer_keeps_app_and_config_root_owned_but_state_writable_by_service_user():
+    script = LINUX_INSTALLER.read_text()
+    layout_section = _section(script, "ensure_layout_dirs(){", "write_environment_file(){")
+
+    assert 'install -d -m 755 -o root -g root "$APP_DIR"' in layout_section
+    assert 'install -d -m 755 -o root -g root "$CONFIG_DIR"' in layout_section
+    assert 'install -d -m 750 -o "$APP_USER" -g "$APP_USER" "$STATE_DIR"' in layout_section
+    assert 'install -d -m 750 -o "$APP_USER" -g "$APP_USER" "$PYCACHE_DIR"' in layout_section
+    assert 'install -d -m 750 -o "$APP_USER" -g "$APP_USER" "$AUDIO_UPLOAD_DIR"' in layout_section
+    assert 'install -d -m 750 -o "$APP_USER" -g "$APP_USER" "$ROADS_CACHE_DIR"' in layout_section
+
+
+def test_linux_installer_stages_code_and_virtualenv_without_app_user_write_access():
+    script = LINUX_INSTALLER.read_text()
+    stage_section = _section(script, "clone_or_stage_project(){", "make_venv_and_install(){")
+    venv_section = _section(script, "make_venv_and_install(){", "write_systemd_service(){")
+
+    assert 'install -d -m 755 -o root -g root "$APP_DIR"' in stage_section
+    assert "link_mutable_state_dirs" in stage_section
+    assert 'chown -R root:root "$APP_DIR"' in stage_section
+    assert 'if ! python3 -m venv "$APP_DIR/venv"; then' in venv_section
+    assert 'command -v virtualenv >/dev/null 2>&1' in venv_section
+    assert 'python3 -m virtualenv --version >/dev/null 2>&1' in venv_section
+    assert 'virtualenv "$APP_DIR/venv" || { echo "virtualenv failed to create $APP_DIR/venv."; exit 1; }' in venv_section
+    assert 'python3 -m virtualenv "$APP_DIR/venv" || { echo "python3 -m virtualenv failed to create $APP_DIR/venv."; exit 1; }' in venv_section
+    assert "Install python3-virtualenv and re-run this script." in venv_section
+    assert 'sudo -u "$APP_USER" python3 -m venv "$APP_DIR/venv"' not in venv_section
+    assert 'sudo -u "$APP_USER" "$APP_DIR/venv/bin/pip"' not in venv_section
+    assert 'python3 -m pip install virtualenv' not in venv_section
+
+
+def test_linux_installer_refuses_to_overwrite_unverified_systemd_units():
+    script = LINUX_INSTALLER.read_text()
+    service_section = _section(script, "write_systemd_service(){", "service_unit_belongs_to_retroiptvguide(){")
+
+    assert 'if [[ -f "$SYSTEMD_FILE" ]] && ! service_unit_belongs_to_retroiptvguide "$SYSTEMD_FILE"; then' in service_section
+    assert "Refusing to overwrite existing systemd unit $SYSTEMD_FILE because it could not be verified as RetroIPTVGuide." in service_section
 
 
 def test_linux_installer_legacy_execstart_regex_matches_supported_paths():
@@ -41,10 +276,366 @@ def test_linux_installer_workingdirectory_regex_matches_supported_paths():
     assert not working_directory_pattern.match("WorkingDirectory=/srv/otherapp")
 
 
-def test_linux_updater_rewrites_current_service_before_legacy_cleanup():
-    script = (REPO_ROOT / "retroiptv_linux.sh").read_text()
+def test_linux_install_and_update_migrate_legacy_state_before_service_cutover():
+    script = LINUX_INSTALLER.read_text()
 
-    update_section = script.split("update_linux(){", 1)[1].split("uninstall_linux(){", 1)[0]
+    install_section = _section(script, "install_linux(){", "update_linux(){")
+    update_section = _section(script, "update_linux(){", "uninstall_linux(){")
 
-    assert "write_systemd_service" in update_section
-    assert update_section.index("write_systemd_service") < update_section.index("cleanup_legacy_service_if_owned")
+    assert install_section.index("migrate_legacy_state_if_present") < install_section.index("write_systemd_service")
+    assert install_section.index("_validate_migration") < install_section.index("write_migration_marker")
+    assert install_section.index("start_and_verify") < install_section.index("cleanup_legacy_installation_if_migration_complete")
+    assert update_section.index("migrate_legacy_state_if_present") < update_section.index("write_systemd_service")
+    assert update_section.index("_validate_migration") < update_section.index("write_migration_marker")
+    assert update_section.index('systemctl daemon-reload; systemctl enable "$SERVICE_NAME"; systemctl restart "$SERVICE_NAME"') < update_section.index("cleanup_legacy_installation_if_migration_complete")
+
+
+def test_linux_installer_reowns_existing_repo_before_root_git_updates():
+    script = LINUX_INSTALLER.read_text()
+    update_section = _section(script, "update_linux(){", "uninstall_linux(){")
+
+    assert 'chown -R root:root "$APP_DIR"' in update_section
+    assert update_section.index('chown -R root:root "$APP_DIR"') < update_section.index("git fetch --all && git reset --hard origin/main")
+
+
+def test_linux_installer_reuses_virtualenv_fallback_for_update_repairs():
+    script = LINUX_INSTALLER.read_text()
+    update_section = _section(script, "update_linux(){", "uninstall_linux(){")
+
+    assert "create_virtualenv(){" in script
+    assert "create_virtualenv" in update_section
+    assert update_section.count('"$APP_DIR/venv/bin/pip" install --upgrade pip') == 1
+    assert update_section.count('"$APP_DIR/venv/bin/pip" install -r "$APP_DIR/requirements.txt"') == 1
+
+
+def test_linux_installer_preserves_legacy_tree_for_rollback_and_safe_uninstall():
+    script = LINUX_INSTALLER.read_text()
+    install_section = _section(script, "install_linux(){", "update_linux(){")
+    uninstall_section = _section(script, "uninstall_linux(){", "purge_linux(){")
+
+    assert 'cleanup_legacy_installation_if_migration_complete' in install_section
+    assert "revert_firewall_selinux" in uninstall_section
+    assert 'remove_unit_file_if_verified "$SERVICE_NAME" "$SYSTEMD_FILE"' in uninstall_section
+    assert 'cleanup_legacy_service_if_owned' not in uninstall_section
+    assert 'retained_summary+="  - $CONFIG_DIR"' in uninstall_section
+    assert 'retained_summary+="  - $STATE_DIR"' in uninstall_section
+    assert 'retained_summary+="  - user/group: $APP_USER"' in uninstall_section
+    assert 'rm -rf "$STATE_DIR"' not in uninstall_section
+    assert 'rm -rf "$CONFIG_DIR"' not in uninstall_section
+
+
+def test_linux_installer_purge_is_explicit_and_targeted():
+    script = LINUX_INSTALLER.read_text()
+    purge_section = _section(script, "purge_linux(){", 'case "$ACTION" in')
+
+    assert "uninstall_linux" not in purge_section
+    assert "revert_firewall_selinux" in purge_section
+    assert 'rm -rf "$CONFIG_DIR"' in purge_section
+    assert 'rm -rf "$STATE_DIR"' in purge_section
+    assert 'rm -rf "$LEGACY_APP_DIR"' in purge_section
+    assert "safe_to_remove_dedicated_user" in purge_section
+    assert 'userdel "$APP_USER"' in purge_section
+    assert 'rm -rf "$LEGACY_LOG_DIR"' not in purge_section
+    assert "Legacy shared account '$LEGACY_APP_USER' is left untouched." in purge_section
+
+
+def test_linux_installer_contains_no_broad_user_wide_kill_or_delete_operations():
+    script = LINUX_INSTALLER.read_text()
+
+    assert "pkill -u" not in script
+    assert "killall " not in script
+    assert "userdel -r" not in script
+    assert "rm -rf /home" not in script
+
+
+def test_linux_installer_uninstall_and_purge_do_not_stop_or_disable_legacy_service_names():
+    script = LINUX_INSTALLER.read_text()
+    uninstall_section = _section(script, "uninstall_linux(){", "purge_linux(){")
+    purge_section = _section(script, "purge_linux(){", 'case "$ACTION" in')
+
+    assert 'systemctl stop "$LEGACY_SERVICE_NAME"' not in uninstall_section
+    assert 'systemctl disable "$LEGACY_SERVICE_NAME"' not in uninstall_section
+    assert 'systemctl stop "$LEGACY_SERVICE_NAME"' not in purge_section
+    assert 'systemctl disable "$LEGACY_SERVICE_NAME"' not in purge_section
+
+
+def test_linux_installer_guards_dedicated_user_removal_with_process_and_file_checks():
+    script = LINUX_INSTALLER.read_text()
+    guard_section = _section(script, "safe_to_remove_dedicated_user(){", "print_cleanup_summary(){")
+
+    assert 'getent passwd "$APP_USER"' in guard_section
+    assert 'pgrep -u "$APP_USER"' in guard_section
+    assert 'find /opt /etc /var/lib /var/log /run /tmp -xdev -user "$APP_USER"' in guard_section
+
+
+def test_linux_installer_legacy_only_uninstall_removes_verified_legacy_project_and_warns_shared_resources():
+    script = LINUX_INSTALLER.read_text()
+    uninstall_section = _section(script, "uninstall_linux(){", "purge_linux(){")
+
+    assert 'legacy_only_resources_present=true' in uninstall_section
+    assert 'remove_unit_file_if_verified "$LEGACY_SERVICE_NAME" "$LEGACY_SYSTEMD_FILE"' in uninstall_section
+    assert 'rm -rf "$LEGACY_APP_DIR"' in uninstall_section
+    assert "Legacy shared user/group/home resources were not deleted automatically" in uninstall_section
+
+
+def test_linux_installer_checks_for_rsync_before_migration_or_staging():
+    script = LINUX_INSTALLER.read_text()
+
+    assert "require_command(){" in script
+    assert "require_command rsync" in script
+
+
+def test_linux_installer_never_targets_sibling_service_names_or_directories():
+    script = LINUX_INSTALLER.read_text()
+
+    # The script may *detect* sibling services to avoid breaking them, but must
+    # never issue destructive operations (rm -rf, systemctl stop/disable) that
+    # directly target those sibling service names or directories.
+    for name in ("retrostation-mc", "retrostation_mc", "retrostationmc", "/home/iptv/RetroStationMC"):
+        # Detection (grep/find/test) is fine; destructive commands are not.
+        for bad_prefix in (f"rm -rf {name}", f"systemctl stop {name}", f"systemctl disable {name}"):
+            assert bad_prefix not in script, f"Script must not destructively target: {bad_prefix}"
+
+
+def test_linux_ci_workflow_runs_install_layout_guardrails():
+    workflow = PYTHON_CI.read_text()
+
+    assert "pytest tests/test_install_scripts.py" in workflow
+
+
+def test_linux_migration_backup_requires_nonempty_archive(tmp_path):
+    result = _run_linux_function_harness(
+        tmp_path,
+        """
+        printf 'legacy-user-db' > "$LEGACY_CONFIG_DIR/users.db"
+        _migration_backup
+        test -s "$MIGRATION_BACKUP_DIR/legacy-state.tar.gz"
+        """,
+    )
+
+    assert result.returncode == 0, result.stderr
+
+
+def test_linux_migration_backup_failure_aborts_before_copy_or_marker(tmp_path):
+    root = tmp_path / "root"
+    result = _run_linux_function_harness(
+        tmp_path,
+        """
+        printf 'legacy-user-db' > "$LEGACY_CONFIG_DIR/users.db"
+        migrate_legacy_state_if_present
+        """,
+        tar_mode="fail",
+    )
+
+    assert result.returncode != 0
+    assert "Migration aborted" in result.stdout
+    assert not (root / "var/lib/retroiptvguide/users.db").exists()
+    assert not (root / "var/lib/retroiptvguide/.migration_v4.9.9").exists()
+    assert (root / "home/iptv/iptv-server/config/users.db").exists()
+
+
+def test_linux_migration_empty_backup_archive_aborts(tmp_path):
+    root = tmp_path / "root"
+    result = _run_linux_function_harness(
+        tmp_path,
+        """
+        printf 'legacy-user-db' > "$LEGACY_CONFIG_DIR/users.db"
+        migrate_legacy_state_if_present
+        """,
+        tar_mode="empty",
+    )
+
+    assert result.returncode != 0
+    assert "empty archive" in result.stdout
+    assert not (root / "var/lib/retroiptvguide/users.db").exists()
+    assert not (root / "var/lib/retroiptvguide/.migration_v4.9.9").exists()
+
+
+def test_linux_migration_successfully_migrates_dbs_and_writes_marker(tmp_path):
+    root = tmp_path / "root"
+    result = _run_linux_function_harness(
+        tmp_path,
+        """
+        printf 'legacy-user-db' > "$LEGACY_CONFIG_DIR/users.db"
+        printf 'legacy-tuner-db' > "$LEGACY_CONFIG_DIR/tuners.db"
+        printf '{"theme":"retro"}' > "$LEGACY_CONFIG_DIR/preferences.json"
+        printf 'print("ok")\\n' > "$APP_DIR/app.py"
+        printf 'flask\\n' > "$APP_DIR/requirements.txt"
+        mkdir -p "$APP_DIR/venv/bin"
+        printf '#!/usr/bin/env bash\\nexit 0\\n' > "$APP_DIR/venv/bin/python3"
+        chmod +x "$APP_DIR/venv/bin/python3"
+        printf 'RETROIPTV_DATA_DIR=%s\\n' "$STATE_DIR" > "$ENV_FILE"
+        printf '[Unit]\\nDescription=RetroIPTVGuide\\n' > "$SYSTEMD_FILE"
+        migrate_legacy_state_if_present
+        _validate_migration
+        write_migration_marker
+        """,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert (root / "var/lib/retroiptvguide/users.db").read_text() == "legacy-user-db"
+    assert (root / "var/lib/retroiptvguide/tuners.db").read_text() == "legacy-tuner-db"
+    assert (root / "var/lib/retroiptvguide/preferences.json").read_text() == '{"theme":"retro"}'
+    marker = root / "var/lib/retroiptvguide/.migration_v4.9.9"
+    assert marker.exists()
+    assert "migration_version=4.9.9" in marker.read_text()
+
+
+def test_linux_failed_validation_does_not_create_marker_or_cleanup_legacy_tree(tmp_path):
+    root = tmp_path / "root"
+    result = _run_linux_function_harness(
+        tmp_path,
+        """
+        printf 'legacy-user-db' > "$LEGACY_CONFIG_DIR/users.db"
+        printf 'print("ok")\\n' > "$APP_DIR/app.py"
+        printf 'flask\\n' > "$APP_DIR/requirements.txt"
+        mkdir -p "$APP_DIR/venv/bin"
+        printf '#!/usr/bin/env bash\\nexit 0\\n' > "$APP_DIR/venv/bin/python3"
+        chmod +x "$APP_DIR/venv/bin/python3"
+        printf 'RETROIPTV_DATA_DIR=%s\\n' "$STATE_DIR" > "$ENV_FILE"
+        printf '[Unit]\\nDescription=RetroIPTVGuide\\n' > "$SYSTEMD_FILE"
+        migrate_legacy_state_if_present
+        rm -f "$STATE_DIR/users.db"
+        if _validate_migration; then
+          write_migration_marker
+          cleanup_legacy_installation_if_migration_complete
+        fi
+        """,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert "Validation: legacy users.db was not copied" in result.stdout
+    assert not (root / "var/lib/retroiptvguide/.migration_v4.9.9").exists()
+    assert (root / "home/iptv/iptv-server").exists()
+
+
+def test_linux_migration_preserves_existing_target_db_and_conflict_copy(tmp_path):
+    root = tmp_path / "root"
+    result = _run_linux_function_harness(
+        tmp_path,
+        """
+        printf 'legacy-user-db' > "$LEGACY_CONFIG_DIR/users.db"
+        printf 'modern-user-db' > "$STATE_DIR/users.db"
+        migrate_legacy_state_if_present
+        """,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert (root / "var/lib/retroiptvguide/users.db").read_text() == "modern-user-db"
+    conflict_copy = root / "var/lib/retroiptvguide/migration-conflicts/v4.9.9-2026-08-07_00-00-00/users.db"
+    assert conflict_copy.read_text() == "legacy-user-db"
+    assert "Migration conflict" in result.stdout
+
+
+def test_linux_migration_moves_legacy_uploads_and_caches(tmp_path):
+    root = tmp_path / "root"
+    result = _run_linux_function_harness(
+        tmp_path,
+        """
+        mkdir -p "$LEGACY_AUDIO_UPLOAD_DIR" "$LEGACY_LOGO_UPLOAD_DIR" "$LEGACY_ROADS_CACHE_DIR" "$LEGACY_BASEMAP_CACHE_DIR"
+        printf 'audio' > "$LEGACY_AUDIO_UPLOAD_DIR/theme.mp3"
+        printf 'logo' > "$LEGACY_LOGO_UPLOAD_DIR/custom.png"
+        printf 'roads' > "$LEGACY_ROADS_CACHE_DIR/city_1.json"
+        printf 'map' > "$LEGACY_BASEMAP_CACHE_DIR/demo.png"
+        migrate_legacy_state_if_present
+        """,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert (root / "var/lib/retroiptvguide/uploads/audio/theme.mp3").read_text() == "audio"
+    assert (root / "var/lib/retroiptvguide/uploads/logos/virtual/custom.png").read_text() == "logo"
+    assert (root / "var/lib/retroiptvguide/cache/roads/city_1.json").read_text() == "roads"
+    assert (root / "var/lib/retroiptvguide/cache/traffic_demo/demo.png").read_text() == "map"
+
+
+def test_linux_installer_links_mutable_app_paths_to_isolated_state():
+    script = LINUX_INSTALLER.read_text()
+    link_section = _section(script, "link_mutable_state_dirs(){", "make_venv_and_install(){")
+
+    assert '"$APP_DIR/static/audio:$AUDIO_UPLOAD_DIR"' in link_section
+    assert '"$APP_DIR/static/logos/virtual/uploads:$LOGO_UPLOAD_DIR"' in link_section
+    assert '"$APP_DIR/data/roads_cache:$ROADS_CACHE_DIR"' in link_section
+    assert '"$APP_DIR/static/maps/traffic_demo:$BASEMAP_CACHE_DIR"' in link_section
+    assert "--exclude 'icon_pack/' --exclude 'uploads/'" in link_section
+    assert 'install -d -m 750 -o "$APP_USER" -g "$APP_USER" "$state_path"' in link_section
+    assert 'rsync -a --ignore-existing "$app_path/" "$state_path/"' in link_section
+    assert 'rm -rf -- "$app_path"' in link_section
+    assert 'install -d -m 755 -o root -g root "$(dirname "$app_path")"' in link_section
+    assert 'ln -s "$state_path" "$app_path"' in link_section
+
+
+def test_linux_installer_moves_bundled_mutable_files_into_state_before_linking(tmp_path):
+    root = tmp_path / "root"
+    result = _run_linux_function_harness(
+        tmp_path,
+        """
+        mkdir -p "$APP_DIR/static/audio" "$APP_DIR/static/maps/traffic_demo"
+        printf 'audio' > "$APP_DIR/static/audio/theme.mp3"
+        printf 'map' > "$APP_DIR/static/maps/traffic_demo/city.png"
+        link_mutable_state_dirs
+        test -L "$APP_DIR/static/audio"
+        test -L "$APP_DIR/static/maps/traffic_demo"
+        """,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert (root / "var/lib/retroiptvguide/uploads/audio/theme.mp3").read_text() == "audio"
+    assert (root / "var/lib/retroiptvguide/cache/traffic_demo/city.png").read_text() == "map"
+
+
+def test_linux_installer_moves_legacy_loose_logo_uploads_without_icon_pack(tmp_path):
+    root = tmp_path / "root"
+    result = _run_linux_function_harness(
+        tmp_path,
+        """
+        mkdir -p "$APP_DIR/static/logos/virtual/icon_pack"
+        printf 'custom' > "$APP_DIR/static/logos/virtual/custom.png"
+        printf 'bundled' > "$APP_DIR/static/logos/virtual/icon_pack/news.png"
+        link_mutable_state_dirs
+        """,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert (root / "var/lib/retroiptvguide/uploads/logos/virtual/custom.png").read_text() == "custom"
+    assert not (root / "var/lib/retroiptvguide/uploads/logos/virtual/icon_pack/news.png").exists()
+
+
+def test_linux_cleanup_preserves_shared_iptv_resources(tmp_path):
+    root = tmp_path / "root"
+    result = _run_linux_function_harness(
+        tmp_path,
+        """
+        mkdir -p "$LEGACY_APP_HOME/RetroStationMC"
+        printf 'migration_version=%s\\n' "$VERSION" > "$MIGRATION_MARKER"
+        cleanup_legacy_installation_if_migration_complete
+        """,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert (root / "home/iptv/iptv-server").exists()
+    assert "retaining" in result.stdout.lower()
+
+
+def test_linux_migration_marker_keeps_second_run_idempotent(tmp_path):
+    root = tmp_path / "root"
+    result = _run_linux_function_harness(
+        tmp_path,
+        """
+        printf 'migration_version=%s\\n' "$VERSION" > "$MIGRATION_MARKER"
+        printf 'legacy-user-db' > "$LEGACY_CONFIG_DIR/users.db"
+        printf 'modern-user-db' > "$STATE_DIR/users.db"
+        migrate_legacy_state_if_present
+        """,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert (root / "var/lib/retroiptvguide/users.db").read_text() == "modern-user-db"
+    assert "Skipping legacy state migration" in result.stdout
+
+
+def test_app_legacy_path_warning_is_single_nonfatal_stderr_notice():
+    app_source = (REPO_ROOT / "app.py").read_text()
+
+    assert "warnings.warn" not in app_source
+    assert "Running from deprecated legacy path" in app_source
+    assert "/home/iptv/iptv-server" in app_source

--- a/tests/test_logo_upload.py
+++ b/tests/test_logo_upload.py
@@ -129,7 +129,7 @@ class TestGetVirtualChannelsCustomLogo:
         from app import get_virtual_channels
         channels = get_virtual_channels()
         news_ch = next(ch for ch in channels if ch['tvg_id'] == 'virtual.news')
-        assert news_ch['logo'] == '/static/logos/virtual/virtual_news_logo.png'
+        assert news_ch['logo'] == '/static/logos/virtual/uploads/virtual_news_logo.png'
 
     def test_no_custom_logo_uses_default(self, tmp_path, monkeypatch):
         monkeypatch.setattr(app_module, "LOGO_UPLOAD_DIR", str(tmp_path / "logos" / "virtual"))

--- a/tests/test_virtual_channels.py
+++ b/tests/test_virtual_channels.py
@@ -2075,7 +2075,7 @@ class TestResolveChannelLogo:
             'virtual_news_logo.png',
             True,
         )
-        assert url == '/static/logos/virtual/virtual_news_logo.png'
+        assert url == '/static/logos/virtual/uploads/virtual_news_logo.png'
 
     def test_custom_logo_takes_priority_when_icon_pack_disabled(self):
         url = _resolve_channel_logo(
@@ -2084,7 +2084,7 @@ class TestResolveChannelLogo:
             'virtual_news_logo.png',
             False,
         )
-        assert url == '/static/logos/virtual/virtual_news_logo.png'
+        assert url == '/static/logos/virtual/uploads/virtual_news_logo.png'
 
     def test_icon_pack_used_when_enabled_and_no_custom(self):
         # The icon pack files exist on disk (they are in the repo)

--- a/utils/health_checks.py
+++ b/utils/health_checks.py
@@ -500,6 +500,7 @@ def check_file_system(db_path: str, tuner_db_path: str, data_dir: str) -> Dict[s
         },
         "app_working_dir": {
             "path": os.path.abspath(os.getcwd()),
+            "exists": os.path.isdir(os.getcwd()),
             "listing": _dir_listing(os.getcwd(), max_entries=40),
         },
     }


### PR DESCRIPTION
## v4.9.9 - 2026-07-21

### Added
- Added Linux installer coverage that guards the dedicated `retroiptvguide` service
  account, `/opt/retroiptvguide` app path, `/etc/retroiptvguide` configuration path,
  `/var/lib/retroiptvguide` state path, safe uninstall behavior, explicit purge behavior,
  and CI enforcement against reintroducing shared `/home/iptv` ownership assumptions.

### Changed
- Standardized Linux installs on the isolated layout:
  - application code and virtualenv in `/opt/retroiptvguide`
  - administrator-managed environment file in `/etc/retroiptvguide`
  - mutable state and app logs in `/var/lib/retroiptvguide`
  - dedicated `retroiptvguide` service account for `retroiptvguide.service`
- Linux migration from `/home/iptv/iptv-server` is now automatic when the v4.9.9+
  installer or updater detects the legacy RetroIPTVGuide layout.
- Automatic migration rewrites the current systemd unit, copies legacy application state
  into `/var/lib/retroiptvguide`, and only removes `iptv-server.service` when that unit
  is confirmed to belong to RetroIPTVGuide.
- Linux uninstall now removes the service and application directory while retaining
  `/etc/retroiptvguide`, `/var/lib/retroiptvguide`, and any untouched legacy tree for
  reinstall or rollback. Explicit `purge` is required to remove retained config/state.

### Fixed
- Removed Linux uninstall behavior that relied on shared-user cleanup patterns such as
  user-wide process termination or recursive user-home deletion.
- Hardened the v4.9.9 legacy-layout migration so backup creation must succeed before
  destructive steps continue, migrated persistent state is validated before the success
  marker is written, legacy state conflicts are preserved explicitly, and safe cleanup
  only runs after validation succeeds.